### PR TITLE
Make sure we have gnutar in scope

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,13 +11,14 @@
       (system:
         let pkgs = nixpkgs.legacyPackages.${system}; in
         {
-          packages.default = pkgs.buildEnv {
+          packages.default = with pkgs; buildEnv {
             name = "cardano-haskell-packages";
             paths = [
-              pkgs.bash
-              pkgs.coreutils
-              pkgs.curl
-              pkgs.git
+              bash
+              coreutils
+              curl
+              git
+              gnutar
               foliage.packages.${system}.default
             ];
           };


### PR DESCRIPTION
The add-from-github script depends on some gnutar specific wildcard behaviour and otherwise fails on run on macOS.

Closes #17.