### PR TITLE
Update metadata to use foliage github backend

### DIFF
--- a/_sources/Win32-network/0.1.0.0/meta.toml
+++ b/_sources/Win32-network/0.1.0.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:38Z
-url = 'https://github.com/input-output-hk/Win32-network/tarball/3825d3abf75f83f406c1f7161883c438dac7277d'
+github = { repo = "input-output-hk/Win32-network", rev = "3825d3abf75f83f406c1f7161883c438dac7277d" }

--- a/_sources/base-deriving-via/0.1.0.0/meta.toml
+++ b/_sources/base-deriving-via/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'base-deriving-via'

--- a/_sources/base-deriving-via/0.1.0.1/meta.toml
+++ b/_sources/base-deriving-via/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'base-deriving-via'

--- a/_sources/byron-spec-chain/0.1.0.0/meta.toml
+++ b/_sources/byron-spec-chain/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/0.1.0.0/meta.toml
+++ b/_sources/byron-spec-ledger/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-binary-test/1.3.0.1/meta.toml
+++ b/_sources/cardano-binary-test/1.3.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'binary/test'

--- a/_sources/cardano-binary-test/1.3.0/meta.toml
+++ b/_sources/cardano-binary-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'binary/test'

--- a/_sources/cardano-binary/1.5.0.1/meta.toml
+++ b/_sources/cardano-binary/1.5.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'binary'

--- a/_sources/cardano-binary/1.5.0/meta.toml
+++ b/_sources/cardano-binary/1.5.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'binary'

--- a/_sources/cardano-crypto-class/2.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-class/2.0.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-crypto-class'

--- a/_sources/cardano-crypto-class/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'cardano-crypto-class'

--- a/_sources/cardano-crypto-praos/2.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-crypto-praos/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-crypto-test/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/crypto/test'

--- a/_sources/cardano-crypto-tests/2.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-crypto-tests'

--- a/_sources/cardano-crypto-tests/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'cardano-crypto-tests'

--- a/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/crypto'

--- a/_sources/cardano-crypto/1.1.0/meta.toml
+++ b/_sources/cardano-crypto/1.1.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-crypto/tarball/f73079303f663e028288f9f4a9e08bcca39a923e'
+github = { repo = "input-output-hk/cardano-crypto", rev = "f73079303f663e028288f9f4a9e08bcca39a923e" }

--- a/_sources/cardano-data/0.1.0.0/meta.toml
+++ b/_sources/cardano-data/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/cardano-data'

--- a/_sources/cardano-ledger-alonzo-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-babbage-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/babbage/test-suite'

--- a/_sources/cardano-ledger-babbage/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-byron-test/1.3.0/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/ledger/impl/test'

--- a/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/byron/ledger/impl'

--- a/_sources/cardano-ledger-core/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-pretty/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-pretty/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/cardano-ledger-pretty'

--- a/_sources/cardano-ledger-shelley-ma-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/shelley-ma/test-suite'

--- a/_sources/cardano-ledger-shelley-ma/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/shelley-ma/impl'

--- a/_sources/cardano-ledger-shelley-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'eras/shelley/impl'

--- a/_sources/cardano-prelude-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-prelude-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:36Z
-url = 'https://github.com/input-output-hk/cardano-prelude/tarball/6ea36cf2247ac0bc33e08c327abec34dfd05bd99'
+github = { repo = "input-output-hk/cardano-prelude", rev = "6ea36cf2247ac0bc33e08c327abec34dfd05bd99" }
 subdir = 'cardano-prelude-test'

--- a/_sources/cardano-prelude-test/0.1.0.1/meta.toml
+++ b/_sources/cardano-prelude-test/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-26T01:58:16Z
-url = 'https://github.com/input-output-hk/cardano-prelude/tarball/f3c145a7f67fe1c1e04828c68fc15608e0debd43'
+github = { repo = "input-output-hk/cardano-prelude", rev = "f3c145a7f67fe1c1e04828c68fc15608e0debd43" }
 subdir = 'cardano-prelude-test'

--- a/_sources/cardano-prelude/0.1.0.0/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:36Z
-url = 'https://github.com/input-output-hk/cardano-prelude/tarball/6ea36cf2247ac0bc33e08c327abec34dfd05bd99'
+github = { repo = "input-output-hk/cardano-prelude", rev = "6ea36cf2247ac0bc33e08c327abec34dfd05bd99" }
 subdir = 'cardano-prelude'

--- a/_sources/cardano-prelude/0.1.0.1/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-26T01:58:16Z
-url = 'https://github.com/input-output-hk/cardano-prelude/tarball/f3c145a7f67fe1c1e04828c68fc15608e0debd43'
+github = { repo = "input-output-hk/cardano-prelude", rev = "f3c145a7f67fe1c1e04828c68fc15608e0debd43" }
 subdir = 'cardano-prelude'

--- a/_sources/cardano-protocol-tpraos/0.1.0.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/cardano-slotting/0.1.0.0/meta.toml
+++ b/_sources/cardano-slotting/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'slotting'

--- a/_sources/cardano-slotting/0.1.0.1/meta.toml
+++ b/_sources/cardano-slotting/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'slotting'

--- a/_sources/cardano-strict-containers/0.1.0.1/meta.toml
+++ b/_sources/cardano-strict-containers/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-strict-containers'

--- a/_sources/contra-tracer/0.1.0.0/meta.toml
+++ b/_sources/contra-tracer/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'contra-tracer'

--- a/_sources/ekg-forward/0.1.0/meta.toml
+++ b/_sources/ekg-forward/0.1.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:43Z
-url = 'https://github.com/input-output-hk/ekg-forward/tarball/297cd9db5074339a2fb2e5ae7d0780debb670c63'
+github = { repo = "input-output-hk/ekg-forward", rev = "297cd9db5074339a2fb2e5ae7d0780debb670c63" }

--- a/_sources/flat/0.4.4.0.0.0.0.1/meta.toml
+++ b/_sources/flat/0.4.4.0.0.0.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:45Z
-url = 'https://github.com/input-output-hk/flat/tarball/ee59880f47ab835dbd73bea0847dab7869fc20d8'
+github = { repo = "input-output-hk/flat", rev = "ee59880f47ab835dbd73bea0847dab7869fc20d8" }
 force-version = true

--- a/_sources/goblins/0.2.0.0/meta.toml
+++ b/_sources/goblins/0.2.0.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/goblins/tarball/cde90a2b27f79187ca8310b6549331e59595e7ba'
+github = { repo = "input-output-hk/goblins", rev = "cde90a2b27f79187ca8310b6549331e59595e7ba" }

--- a/_sources/heapwords/0.1.0.1/meta.toml
+++ b/_sources/heapwords/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'heapwords'

--- a/_sources/hedgehog-extras/0.2.0.0/meta.toml
+++ b/_sources/hedgehog-extras/0.2.0.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/hedgehog-extras/tarball/714ee03a5a786a05fc57ac5d2f1c2edce4660d85'
+github = { repo = "input-output-hk/hedgehog-extras", rev = "714ee03a5a786a05fc57ac5d2f1c2edce4660d85" }

--- a/_sources/io-classes/0.2.0.0/meta.toml
+++ b/_sources/io-classes/0.2.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:40Z
-url = 'https://github.com/input-output-hk/io-sim/tarball/f4183f274d88d0ad15817c7052df3a6a8b40e6dc'
+github = { repo = "input-output-hk/io-sim", rev = "f4183f274d88d0ad15817c7052df3a6a8b40e6dc" }
 subdir = 'io-classes'

--- a/_sources/io-sim/0.2.0.0/meta.toml
+++ b/_sources/io-sim/0.2.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:40Z
-url = 'https://github.com/input-output-hk/io-sim/tarball/f4183f274d88d0ad15817c7052df3a6a8b40e6dc'
+github = { repo = "input-output-hk/io-sim", rev = "f4183f274d88d0ad15817c7052df3a6a8b40e6dc" }
 subdir = 'io-sim'

--- a/_sources/iohk-monitoring/0.1.11.0/meta.toml
+++ b/_sources/iohk-monitoring/0.1.11.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'iohk-monitoring'

--- a/_sources/lobemo-backend-aggregation/0.1.0.0/meta.toml
+++ b/_sources/lobemo-backend-aggregation/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'plugins/backend-aggregation'

--- a/_sources/lobemo-backend-ekg/0.1.0.1/meta.toml
+++ b/_sources/lobemo-backend-ekg/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'plugins/backend-ekg'

--- a/_sources/lobemo-backend-monitoring/0.1.0.0/meta.toml
+++ b/_sources/lobemo-backend-monitoring/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'plugins/backend-monitoring'

--- a/_sources/lobemo-backend-trace-forwarder/0.1.0.0/meta.toml
+++ b/_sources/lobemo-backend-trace-forwarder/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'plugins/backend-trace-forwarder'

--- a/_sources/lobemo-scribe-systemd/0.1.0.0/meta.toml
+++ b/_sources/lobemo-scribe-systemd/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'plugins/scribe-systemd'

--- a/_sources/measures/0.1.0.0/meta.toml
+++ b/_sources/measures/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'measures'

--- a/_sources/measures/0.1.0.1/meta.toml
+++ b/_sources/measures/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'measures'

--- a/_sources/monoidal-synchronisation/0.1.0.0/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'monoidal-synchronisation'

--- a/_sources/network-mux/0.1.0.0/meta.toml
+++ b/_sources/network-mux/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'network-mux'

--- a/_sources/non-integral/0.1.0.0/meta.toml
+++ b/_sources/non-integral/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/non-integral'

--- a/_sources/optparse-applicative-fork/0.16.1.0/meta.toml
+++ b/_sources/optparse-applicative-fork/0.16.1.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2022-08-31T08:36:30Z
-url = 'https://github.com/input-output-hk/optparse-applicative/tarball/7497a29cb998721a9068d5725d49461f2bba0e7a'
+github = { repo = "input-output-hk/optparse-applicative", rev = "7497a29cb998721a9068d5725d49461f2bba0e7a" }

--- a/_sources/orphans-deriving-via/0.1.0.0/meta.toml
+++ b/_sources/orphans-deriving-via/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'orphans-deriving-via'

--- a/_sources/orphans-deriving-via/0.1.0.1/meta.toml
+++ b/_sources/orphans-deriving-via/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-09-27T00:17:36Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1'
+github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'orphans-deriving-via'

--- a/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-consensus-byron'

--- a/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-protocol/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus-shelley/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-consensus-shelley'

--- a/_sources/ouroboros-consensus/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-consensus'

--- a/_sources/ouroboros-network-framework/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network-framework/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-testing/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network-testing/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-network-testing'

--- a/_sources/ouroboros-network/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:39Z
-url = 'https://github.com/input-output-hk/ouroboros-network/tarball/c764553561bed8978d2c6753d1608dc65449617a'
+github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
 subdir = 'ouroboros-network'

--- a/_sources/plutus-core/1.0.0.0/meta.toml
+++ b/_sources/plutus-core/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'plutus-core'

--- a/_sources/plutus-ghc-stub/8.6.5/meta.toml
+++ b/_sources/plutus-ghc-stub/8.6.5/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'stubs/plutus-ghc-stub'

--- a/_sources/plutus-ledger-api/1.0.0.0/meta.toml
+++ b/_sources/plutus-ledger-api/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'plutus-ledger-api'

--- a/_sources/plutus-tx-plugin/1.0.0.0/meta.toml
+++ b/_sources/plutus-tx-plugin/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'plutus-tx-plugin'

--- a/_sources/plutus-tx/1.0.0.0/meta.toml
+++ b/_sources/plutus-tx/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'plutus-tx'

--- a/_sources/prettyprinter-configurable/0.1.0.0/meta.toml
+++ b/_sources/prettyprinter-configurable/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'prettyprinter-configurable'

--- a/_sources/set-algebra/0.1.0.0/meta.toml
+++ b/_sources/set-algebra/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/set-algebra'

--- a/_sources/small-steps-test/0.1.0.0/meta.toml
+++ b/_sources/small-steps-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/small-steps-test'

--- a/_sources/small-steps/0.1.0.0/meta.toml
+++ b/_sources/small-steps/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/small-steps'

--- a/_sources/strict-containers/0.1.0.0/meta.toml
+++ b/_sources/strict-containers/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:31Z
-url = 'https://github.com/input-output-hk/cardano-base/tarball/a3c13fb11bc41fedff7885ca70a3b33f61fef4b5'
+github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
 subdir = 'strict-containers'

--- a/_sources/strict-stm/0.1.0.0/meta.toml
+++ b/_sources/strict-stm/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:40Z
-url = 'https://github.com/input-output-hk/io-sim/tarball/f4183f274d88d0ad15817c7052df3a6a8b40e6dc'
+github = { repo = "input-output-hk/io-sim", rev = "f4183f274d88d0ad15817c7052df3a6a8b40e6dc" }
 subdir = 'strict-stm'

--- a/_sources/tracer-transformers/0.1.0.1/meta.toml
+++ b/_sources/tracer-transformers/0.1.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:37Z
-url = 'https://github.com/input-output-hk/iohk-monitoring-framework/tarball/066f7002aac5a0efc20e49643fea45454f226caa'
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "066f7002aac5a0efc20e49643fea45454f226caa" }
 subdir = 'tracer-transformers'

--- a/_sources/typed-protocols-cborg/0.1.0.0/meta.toml
+++ b/_sources/typed-protocols-cborg/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:41Z
-url = 'https://github.com/input-output-hk/typed-protocols/tarball/181601bc3d9e9d21a671ce01e0b481348b3ca104'
+github = { repo = "input-output-hk/typed-protocols", rev = "181601bc3d9e9d21a671ce01e0b481348b3ca104" }
 subdir = 'typed-protocols-cborg'

--- a/_sources/typed-protocols-examples/0.1.0.0/meta.toml
+++ b/_sources/typed-protocols-examples/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:41Z
-url = 'https://github.com/input-output-hk/typed-protocols/tarball/181601bc3d9e9d21a671ce01e0b481348b3ca104'
+github = { repo = "input-output-hk/typed-protocols", rev = "181601bc3d9e9d21a671ce01e0b481348b3ca104" }
 subdir = 'typed-protocols-examples'

--- a/_sources/typed-protocols/0.1.0.0/meta.toml
+++ b/_sources/typed-protocols/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:41Z
-url = 'https://github.com/input-output-hk/typed-protocols/tarball/181601bc3d9e9d21a671ce01e0b481348b3ca104'
+github = { repo = "input-output-hk/typed-protocols", rev = "181601bc3d9e9d21a671ce01e0b481348b3ca104" }
 subdir = 'typed-protocols'

--- a/_sources/vector-map/0.1.0.0/meta.toml
+++ b/_sources/vector-map/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:32Z
-url = 'https://github.com/input-output-hk/cardano-ledger/tarball/f49879a79098d9372d63baa13b94a941a56eda34'
+github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
 subdir = 'libs/vector-map'

--- a/_sources/word-array/0.1.0.0/meta.toml
+++ b/_sources/word-array/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2022-08-31T08:36:42Z
-url = 'https://github.com/input-output-hk/plutus/tarball/f680ac6979e069fcc013e4389ee607ff5fa6672f'
+github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
 subdir = 'word-array'

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661945531,
-        "narHash": "sha256-Z0DX6r9uy+3sC2LiGFdn/CrPpMnWGJ5pefBuxSM4Zis=",
+        "lastModified": 1664460140,
+        "narHash": "sha256-R+jMYcdBeDkXZQiRlsDksNpUbyp9BHCjbRVX+W2Ck1A=",
         "owner": "andreabedini",
         "repo": "foliage",
-        "rev": "1a91935397ae804e3123e7cb307063600769ce53",
+        "rev": "166b340d1323d363df9665aca67e99ba5089def3",
         "type": "github"
       },
       "original": {

--- a/scripts/add-from-github.sh
+++ b/scripts/add-from-github.sh
@@ -61,12 +61,15 @@ fi
 
 render_meta() {
   local TIMESTAMP=$1
-  local URL=$2
-  local SUBDIR=$3
-  local FORCE_VERSION=$4
+  local REPO_URL=$2
+  local REPO_REV=$3
+  local SUBDIR=$4
+  local FORCE_VERSION=$5
+
+  local REPO=${REPO_URL#https://github.com/}
 
   echo "timestamp = $TIMESTAMP"
-  echo "url = '$URL'"
+  echo "github = { repo = \"$REPO\", rev = \"$REPO_REV\" }"
   if [[ -n $SUBDIR ]]; then
     echo "subdir = '$SUBDIR'"
   fi
@@ -84,9 +87,10 @@ warning() {
 }
 
 do_package() {
-  local URL=$1
-  local SUBDIR=$2
-  local WORKDIR=$3
+  local REPO_URL=$1
+  local REPO_REV=$2
+  local SUBDIR=$3
+  local WORKDIR=$4
 
   local CABAL_FILE
   CABAL_FILE=$(echo "$WORKDIR"/"$SUBDIR"/*.cabal)
@@ -122,7 +126,7 @@ do_package() {
   fi
 
   mkdir -p "$(dirname "$METAFILE")"
-  render_meta "$TIMESTAMP" "$URL" "$SUBDIR" "$REVISION$VERSION" > "$METAFILE"
+  render_meta "$TIMESTAMP" "$REPO_URL" "$REPO_REV" "$SUBDIR" "$REVISION$VERSION" > "$METAFILE"
   log "Written $METAFILE"
 
   git add "$METAFILE"
@@ -147,10 +151,10 @@ tar xzf ./* --strip-component=1 --wildcards '**/*.cabal'
 popd
 
 if [[ ${#SUBDIRS[@]} -eq 0 ]]; then
-  do_package "$TAR_URL" "" "$WORKDIR"
+  do_package "$REPO_URL" "$REPO_REV" "" "$WORKDIR"
 else
   for subdir in "${SUBDIRS[@]}"; do
-    do_package "$TAR_URL" "$subdir" "$WORKDIR"
+    do_package "$REPO_URL" "$REPO_REV" "$subdir" "$WORKDIR"
   done
 fi
 

--- a/scripts/add-from-github.sh
+++ b/scripts/add-from-github.sh
@@ -59,6 +59,11 @@ if [[ ${#SUBDIRS[@]} -gt 1 && (-n $VERSION || -n $REVISION) ]]; then
   exit 1
 fi
 
+if [[ ! "$REPO_URL" =~ "https://github.com/" ]]; then
+  echo "Provided url is not a github url: $REPO_URL"
+  exit 1
+fi
+
 render_meta() {
   local TIMESTAMP=$1
   local REPO_URL=$2


### PR DESCRIPTION
This updates everything (metadata and script) to use foliage github backend. This is so that foliage knows the details about the github repo and can use it for other tihngs (e.g. webpages or adding metadata in the cabal files).

I checked this does not cause any extra changes. On my computer only the signatures change (obviously has I don't have the same keys). Most importantly the hashes of the sdists do not change. Please test again yourself :-)