### PR TITLE
Added flat-0.4.4.0.0.0.0.2

### DIFF
--- a/_sources/flat/0.4.4.0.0.0.0.2/meta.toml
+++ b/_sources/flat/0.4.4.0.0.0.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-14T15:45:38Z
+github = { repo = "input-output-hk/flat", rev = "3bd82065ec7f8f253bcb18832b200dbf07707a3b" }
+force-version = true


### PR DESCRIPTION
From https://github.com/input-output-hk/flat at 3bd82065ec7f8f253bcb18832b200dbf07707a3b

Needed for 9.2 support.