### PR TITLE
Node 1.35.3

### DIFF
--- a/_sources/base-deriving-via/0.1.0.0/meta.toml
+++ b/_sources/base-deriving-via/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'base-deriving-via'

--- a/_sources/byron-spec-chain/0.1.0.0/meta.toml
+++ b/_sources/byron-spec-chain/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/0.1.0.0/meta.toml
+++ b/_sources/byron-spec-ledger/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-binary-test/1.3.0/meta.toml
+++ b/_sources/cardano-binary-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'binary/test'

--- a/_sources/cardano-binary/1.5.0/meta.toml
+++ b/_sources/cardano-binary/1.5.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'binary'

--- a/_sources/cardano-client/0.1.0.0/meta.toml
+++ b/_sources/cardano-client/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'cardano-client'

--- a/_sources/cardano-crypto-class/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'cardano-crypto-class'

--- a/_sources/cardano-crypto-praos/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-crypto-test/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/crypto/test'

--- a/_sources/cardano-crypto-tests/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'cardano-crypto-tests'

--- a/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/crypto'

--- a/_sources/cardano-data/0.1.0.0/meta.toml
+++ b/_sources/cardano-data/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/cardano-data'

--- a/_sources/cardano-ledger-alonzo-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-babbage-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/babbage/test-suite'

--- a/_sources/cardano-ledger-babbage/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-byron-test/1.3.0/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.3.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/ledger/impl/test'

--- a/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/ledger/impl'

--- a/_sources/cardano-ledger-core/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-pretty/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-pretty/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/cardano-ledger-pretty'

--- a/_sources/cardano-ledger-shelley-ma-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/shelley-ma/test-suite'

--- a/_sources/cardano-ledger-shelley-ma/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/shelley-ma/impl'

--- a/_sources/cardano-ledger-shelley-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/shelley/impl'

--- a/_sources/cardano-ledger-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
+subdir = 'libs/cardano-ledger-test'

--- a/_sources/cardano-prelude-test/0.1.0.0/meta.toml
+++ b/_sources/cardano-prelude-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:36Z
-github = { repo = "input-output-hk/cardano-prelude", rev = "6ea36cf2247ac0bc33e08c327abec34dfd05bd99" }
+timestamp = 2022-10-17T17:16:47Z
+github = { repo = "input-output-hk/cardano-prelude", rev = "bb4ed71ba8e587f672d06edf9d2e376f4b055555" }
 subdir = 'cardano-prelude-test'

--- a/_sources/cardano-prelude/0.1.0.0/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:36Z
-github = { repo = "input-output-hk/cardano-prelude", rev = "6ea36cf2247ac0bc33e08c327abec34dfd05bd99" }
+timestamp = 2022-10-17T17:16:47Z
+github = { repo = "input-output-hk/cardano-prelude", rev = "bb4ed71ba8e587f672d06edf9d2e376f4b055555" }
 subdir = 'cardano-prelude'

--- a/_sources/cardano-protocol-tpraos/0.1.0.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/cardano-slotting/0.1.0.0/meta.toml
+++ b/_sources/cardano-slotting/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'slotting'

--- a/_sources/ledger-state/0.1.0.0/meta.toml
+++ b/_sources/ledger-state/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
+subdir = 'libs/ledger-state'

--- a/_sources/measures/0.1.0.0/meta.toml
+++ b/_sources/measures/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'measures'

--- a/_sources/monoidal-synchronisation/0.1.0.0/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'monoidal-synchronisation'

--- a/_sources/network-mux/0.1.0.0/meta.toml
+++ b/_sources/network-mux/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'network-mux'

--- a/_sources/non-integral/0.1.0.0/meta.toml
+++ b/_sources/non-integral/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/non-integral'

--- a/_sources/ntp-client/0.0.1/meta.toml
+++ b/_sources/ntp-client/0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ntp-client'

--- a/_sources/orphans-deriving-via/0.1.0.0/meta.toml
+++ b/_sources/orphans-deriving-via/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'orphans-deriving-via'

--- a/_sources/ouroboros-consensus-byron-test/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-byron-test'

--- a/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-byron'

--- a/_sources/ouroboros-consensus-byronspec/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byronspec/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-byronspec'

--- a/_sources/ouroboros-consensus-cardano-test/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-cardano-test'

--- a/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-mock-test/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-mock-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-mock-test'

--- a/_sources/ouroboros-consensus-mock/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-mock/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-mock'

--- a/_sources/ouroboros-consensus-protocol/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus-shelley-test/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-shelley-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-shelley-test'

--- a/_sources/ouroboros-consensus-shelley/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-shelley'

--- a/_sources/ouroboros-consensus-test/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-test/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
+subdir = 'ouroboros-consensus-test'

--- a/_sources/ouroboros-consensus/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus'

--- a/_sources/ouroboros-network-framework/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network-framework/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-testing/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network-testing/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-network-testing'

--- a/_sources/ouroboros-network/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-network/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:39Z
-github = { repo = "input-output-hk/ouroboros-network", rev = "c764553561bed8978d2c6753d1608dc65449617a" }
+timestamp = 2022-10-17T17:17:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-network'

--- a/_sources/plutus-core/1.0.0.0/meta.toml
+++ b/_sources/plutus-core/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'plutus-core'

--- a/_sources/plutus-ghc-stub/8.6.5/meta.toml
+++ b/_sources/plutus-ghc-stub/8.6.5/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'stubs/plutus-ghc-stub'

--- a/_sources/plutus-ledger-api/1.0.0.0/meta.toml
+++ b/_sources/plutus-ledger-api/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'plutus-ledger-api'

--- a/_sources/plutus-preprocessor/0.1.0.0/meta.toml
+++ b/_sources/plutus-preprocessor/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
+subdir = 'libs/plutus-preprocessor'

--- a/_sources/plutus-tx-plugin/1.0.0.0/meta.toml
+++ b/_sources/plutus-tx-plugin/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'plutus-tx-plugin'

--- a/_sources/plutus-tx/1.0.0.0/meta.toml
+++ b/_sources/plutus-tx/1.0.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'plutus-tx'

--- a/_sources/prettyprinter-configurable/0.1.0.0/meta.toml
+++ b/_sources/prettyprinter-configurable/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'prettyprinter-configurable'

--- a/_sources/set-algebra/0.1.0.0/meta.toml
+++ b/_sources/set-algebra/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/set-algebra'

--- a/_sources/small-steps-test/0.1.0.0/meta.toml
+++ b/_sources/small-steps-test/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/small-steps-test'

--- a/_sources/small-steps/0.1.0.0/meta.toml
+++ b/_sources/small-steps/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/small-steps'

--- a/_sources/strict-containers/0.1.0.0/meta.toml
+++ b/_sources/strict-containers/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:31Z
-github = { repo = "input-output-hk/cardano-base", rev = "a3c13fb11bc41fedff7885ca70a3b33f61fef4b5" }
+timestamp = 2022-10-17T17:17:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'strict-containers'

--- a/_sources/vector-map/0.1.0.0/meta.toml
+++ b/_sources/vector-map/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:32Z
-github = { repo = "input-output-hk/cardano-ledger", rev = "f49879a79098d9372d63baa13b94a941a56eda34" }
+timestamp = 2022-10-17T17:16:10Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/vector-map'

--- a/_sources/word-array/0.1.0.0/meta.toml
+++ b/_sources/word-array/0.1.0.0/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-08-31T08:36:42Z
-github = { repo = "input-output-hk/plutus", rev = "f680ac6979e069fcc013e4389ee607ff5fa6672f" }
+timestamp = 2022-10-17T17:17:00Z
+github = { repo = "input-output-hk/plutus", rev = "a56c96598b4b25c9e28215214d25189331087244" }
 subdir = 'word-array'


### PR DESCRIPTION
This breaks history, but is needed because the current listed revisions aren't from the latest node release.