### PR TITLE
Added moo-1.2.0.0.0.0.1

### DIFF
--- a/_sources/moo/1.2.0.0.0.0.1/meta.toml
+++ b/_sources/moo/1.2.0.0.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-19T10:03:21Z
+github = { repo = "input-output-hk/moo", rev = "8c487714fbfdea66188fcb85053e7e292e0cc348" }
+force-version = true


### PR DESCRIPTION
From https://github.com/input-output-hk/moo at 8c487714fbfdea66188fcb85053e7e292e0cc348

It has a duplicate package stanza which means it breaks with cabal-3.8. The dependency has been removed from the ledger, but still exists for the currently-released versions, so it's worth patching it here.