### PR TITLE
Added cardano-crypto-class-2.0.0.0.1

### DIFF
--- a/_sources/cardano-crypto-class/2.0.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-class/2.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2022-10-21T18:32:30Z
+github = { repo = "input-output-hk/cardano-base", rev = "cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" }
+subdir = 'cardano-crypto-class'
+force-version = true


### PR DESCRIPTION
Needed for SECP release without having to refactor the heapwords changes into ledger.

From https://github.com/input-output-hk/cardano-base at cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c