### PR TITLE
dependency bumps for node 1.35.4

### DIFF
--- a/_sources/cardano-client/0.1.0.1/meta.toml
+++ b/_sources/cardano-client/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'cardano-client'

--- a/_sources/cardano-crypto-praos/2.0.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2022-10-25T16:40:34Z
+github = { repo = "input-output-hk/cardano-base", rev = "cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" }
+subdir = 'cardano-crypto-praos'
+force-version = true

--- a/_sources/cardano-crypto-tests/2.0.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2022-10-25T16:40:49Z
+github = { repo = "input-output-hk/cardano-base", rev = "cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" }
+subdir = 'cardano-crypto-tests'
+force-version = true

--- a/_sources/monoidal-synchronisation/0.1.0.1/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'monoidal-synchronisation'

--- a/_sources/network-mux/0.1.0.1/meta.toml
+++ b/_sources/network-mux/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'network-mux'

--- a/_sources/ouroboros-consensus-byron-test/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-byron-test/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-byron-test'

--- a/_sources/ouroboros-consensus-byron/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-byron'

--- a/_sources/ouroboros-consensus-byronspec/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-byronspec/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-byronspec'

--- a/_sources/ouroboros-consensus-cardano-test/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano-test/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-cardano-test'

--- a/_sources/ouroboros-consensus-cardano-tools/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano-tools/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-cardano-tools'

--- a/_sources/ouroboros-consensus-cardano/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-mock-test/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-mock-test/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-mock-test'

--- a/_sources/ouroboros-consensus-mock/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-mock/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-mock'

--- a/_sources/ouroboros-consensus-protocol/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus-shelley-test/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-shelley-test/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-shelley-test'

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-shelley'

--- a/_sources/ouroboros-consensus-test/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-test/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus-test'

--- a/_sources/ouroboros-consensus/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-consensus'

--- a/_sources/ouroboros-network-framework/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-network-framework/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-testing/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-network-testing/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-network-testing'

--- a/_sources/ouroboros-network/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-network/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-10-25T17:33:07Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
+subdir = 'ouroboros-network'


### PR DESCRIPTION
Need to include a couple more packages from base for the 2.0.0.0.1 version

Need a bug fix in consensus that prevents the intra-era hard fork from occurring