### PR TITLE
Add script to check whether the newly built archive is an extension of the previous one

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,16 +27,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: check
 
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/cache@v3
-        with:
-          path: _cache
-          key: 1 # bump to refresh
-
       - name: Setup Nix
         uses: cachix/install-nix-action@v17
         with:
@@ -45,14 +37,40 @@ jobs:
             substituters        = https://cache.iog.io https://cache.nixos.org https://foliage.cachix.org
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= foliage.cachix.org-1:kAFyYLnk8JcRURWReWZCatM9v3Rk24F5wNMpEj14Q/g=
 
+      - name: Checkout main 
+        uses: actions/checkout@v3
+        with:
+          ref: main
+             
+      - uses: actions/cache@v3
+        with:
+          path: _cache
+          key: 1 # bump to refresh
+
       - name: Unpack keys
         env:
           KEYS: ${{ secrets.KEYS }}
         run: |
-          mkdir _keys
-          echo "$KEYS" | base64 -d | tar xvz -C _keys
+          if [[ -z "$KEYS" ]]; then
+            echo "Could not access repository secret keys (PR is coming from a fork?)"
+            echo "Generating fresh keys for this run"
+            nix develop -c foliage create-keys
+          else 
+            mkdir _keys
+            echo "$KEYS" | base64 -d | tar xvz -C _keys
+          fi
 
-      - name: Build repository
+      - name: Build repository (main)
+        run: |
+          nix develop -c foliage build
+          mv _repo _repo-main
+
+      - name: Checkout tip commit
+        uses: actions/checkout@v3
+        with:
+          clean: false
+
+      - name: Build repository (tip)
         run: |
           nix develop -c foliage build
 
@@ -61,16 +79,61 @@ jobs:
           cp static/index.html _repo
           cp README.md _repo
 
+      # Do this before the check, useful to have the artifact in case the 
+      # check fails!
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: built-repo
           path: _repo
 
+      # Note: we use the check script from the tip so we pick up changes 
+      # to the script from the PR itself.
+      - name: Check new index is an extension of the old index
+        run: |
+          ./scripts/check-archive-extension.sh _repo-main/01-index.tar _repo/01-index.tar
+          echo "If this check failed because 'some entries only exist in the old index'"
+          echo "then you may need to update your branch.\n"
+          echo "If it failed because 'the last old entry is newer than the first new entry'"
+          echo "then you may need to update the timestamps in your new packages to be newer than those in main."
+
+  deploy-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: 
+      - build
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src
+
+      - uses: actions/checkout@v3
+        with:
+          path: repo
+          ref: repo
+
+      - name: Download built repository
+        uses: actions/download-artifact@v3
+        with:
+          name: built-repo
+          path: built-repo
+
+      # This is meaningfully different to the check in 'build': that checks the repository
+      # built from main and from the PR tip, but that's not _actually_ the repository
+      # deployed in the repo branch. It should be the same, but it can't hurt to check
+      # against the thing that's actually deployed before we deploy.
+      - name: Check new index is an extension of the old index
+        run: |
+          ./src/scripts/check-archive-extension.sh repo/01-index.tar built-repo/01-index.tar
+
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
+    needs: 
+      - check
+      - build
+      - deploy-check
 
     concurrency:
       group: "pages"

--- a/scripts/check-archive-extension.sh
+++ b/scripts/check-archive-extension.sh
@@ -1,0 +1,111 @@
+#! /usr/bin/env bash
+
+# for some reason you can't just put a heredoc in a variable...
+read -r -d '' USAGE << EOF
+check-archive-extension.sh OLD_ARCHIVE NEW_ARCHIVE
+  Checks whether NEW_ARCHIVE is an extension of OLD_ARCHIVE. That means
+  a) all the entries in OLD_ARCHIVE are in NEW_ARCHIVE
+  b) all the new entries in NEW_ARCHIVE have later timestamps than all
+     the entries in OLD_ARCHIVE
+
+  This is sensitive to file contents in that it checks their sizes. In
+  theory you could defeat this with a file that has the exact same size
+  but different contents, but that's obscure and this isn't intended to
+  be robust to malicious users.
+EOF
+
+if [ "$#" == "0" ]; then
+	echo "$USAGE"
+	exit 1
+fi
+
+OLD_INDEX_TAR=$1
+NEW_INDEX_TAR=$2
+
+# Byte-wise comparison
+# The basic idea is to check whether the two files are byte-wise identical, up
+# to the end of the length of the first file. That shows that the first file is
+# a prefix of the second file.
+#
+# But tar archives are a list of entries terminated by two 512-byte blocks of zeros,
+# so to compare the whole content of the old index, we compare up to the length
+# minus the zero blocks.
+
+OLD_INDEX_BYTES=$(wc -c < $OLD_INDEX_TAR)
+OLD_INDEX_BYTES_TRIMMED="$(($OLD_INDEX_BYTES-1024))"
+BYTE_DIFF=$(cmp -n "$OLD_INDEX_BYTES_TRIMMED" "$OLD_INDEX_TAR" "$NEW_INDEX_TAR")
+
+if [ $? = 0 ]
+then
+  echo "Old archive is a byte-wise prefix of the new archive"
+  exit 0
+else
+  echo "$BYTE_DIFF"
+  echo "ERROR: old archive is not a byte-wise prefix of the new archive, looking for differences"
+fi
+
+# Output looks like this:
+# -rw-r--r-- foliage/foliage  6976 2022-10-25 18:33 network-mux/0.1.0.1/network-mux.cabal
+# So fields 4 and 5 are the date and the time
+OLD_LISTING=$(tar -tvf "$OLD_INDEX_TAR" | sort -k4,5)
+NEW_LISTING=$(tar -tvf "$NEW_INDEX_TAR" | sort -k4,5)
+
+DIFF=$(diff <(echo "$OLD_LISTING") <(echo "$NEW_LISTING"))
+
+if [ $? = 0 ]
+then
+  echo "Archive listings are identical"
+  exit 1
+fi
+
+NEW_INDEX_ONLY=$(echo "$DIFF" | grep -P "^>")
+OLD_INDEX_ONLY=$(echo "$DIFF" | grep -P "^<")
+
+if [[ ! -z "$OLD_INDEX_ONLY" ]]; then
+  echo "ERROR: some entries exist only in the old index"
+  echo "$OLD_INDEX_ONLY"
+  exit 1
+else
+  echo "All listing differences are in the new index"
+  echo "$NEW_INDEX_ONLY"
+fi
+
+LAST_OLD_ENTRY=$(echo "$OLD_LISTING" | tail -n1)
+# Take the first thing that appears only in the new, cut out the ">" marker 
+# Note: this cannot be empty since:
+# 1. The diff was not empty
+# 2. The diff on the old side was empty
+# therefore the diff on the new side must be non-empty
+FIRST_ACTUALLY_NEW_ENTRY=$(echo "$NEW_INDEX_ONLY" | head -n1 | cut -f"2-" -d' ')
+
+function getDate (){
+  echo "$1" | tr -s ' ' | cut -f4,5 -d' ' | tr ' ' '-'
+}
+
+LAST_OLD_DATE=$(getDate "$LAST_OLD_ENTRY")
+FIRST_ACTUALLY_NEW_DATE=$(getDate "$FIRST_ACTUALLY_NEW_ENTRY")
+
+
+# Standard string comparison will do the job here, because
+# we're comparing dates in the format YYYY-MM-DD-HH:MM!
+if [[ $LAST_OLD_DATE > $FIRST_ACTUALLY_NEW_DATE ]]; then
+  echo "ERROR: Last old entry is newer than first new entry"
+  echo "Last old entry:"
+  echo "$LAST_OLD_ENTRY"
+  echo "First new entry:"
+  echo "$FIRST_ACTUALLY_NEW_ENTRY"
+  exit 1
+elif [[ $LAST_OLD_DATE = $FIRST_ACTUALLY_NEW_DATE ]]; then
+  echo "The first new entry has the same timestamp as the last old entry"
+  echo "This may mean that they are not ordered correctly since foliage sorts by timestamp only"
+  echo "Last old entry:"
+  echo "$LAST_OLD_ENTRY"
+  echo "First new entry:"
+  echo "$FIRST_ACTUALLY_NEW_ENTRY"
+  exit 1
+else 
+  echo "All new entries are strictly newer than the last old entry"
+fi
+
+echo "Could not ascertain the reason for the difference between the archives!"
+exit 1


### PR DESCRIPTION
I didn't have time to set this up in the GHA, it's changed a bit and I'm not sure what's going on right now. Maybe you can take a look @andreabedini ?

I tested this a bit and it seems to do the job. I tried:
- Adding a package with an old timestamp (BAD)
- Adding a package with a new timestamp (GOOD)
- Removing a package (BAD)
- Changing the timestamp of a package (BAD)