### PR TITLE
Publish cardano-api-1.35.4

### DIFF
--- a/_sources/cardano-api/1.35.4/meta.toml
+++ b/_sources/cardano-api/1.35.4/meta.toml
@@ -1,3 +1,3 @@
-timestamp = 2022-11-09T20:07:43Z
+timestamp = 2022-11-10T18:00:00Z
 github = { repo = "input-output-hk/cardano-node", rev = "ebc7be471b30e5931b35f9bbc236d21c375b91bb" }
 subdir = 'cardano-api'

--- a/_sources/cardano-api/1.35.4/meta.toml
+++ b/_sources/cardano-api/1.35.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-11-09T20:07:43Z
+github = { repo = "input-output-hk/cardano-node", rev = "ebc7be471b30e5931b35f9bbc236d21c375b91bb" }
+subdir = 'cardano-api'


### PR DESCRIPTION
This is the version released with from https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4 and should be fine to add as it builds & tests pass with all `source-repository-packages` removed.