### PR TITLE
Start a CODEOWNERS file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!-- 
+If you are adding a new package, consider adding yourself or an appropriate
+GitHub team to CODEOWNERS for the new package. See the README for more details.
+-->

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,80 @@
+# cardano-node
+# No team?
+
+# cardano-ledger
+
+_sources/byron-spec-chain        @input-output-hk/cardano-ledger 
+_sources/byron-spec-ledger       @input-output-hk/cardano-ledger 
+_sources/cardano-crypto-test     @input-output-hk/cardano-ledger 
+_sources/cardano-crypto-wrapper  @input-output-hk/cardano-ledger 
+_sources/cardano-data            @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-core     @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-pretty   @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-test     @input-output-hk/cardano-ledger 
+_sources/cardano-protocol-tpraos @input-output-hk/cardano-ledger 
+_sources/ledger-state            @input-output-hk/cardano-ledger 
+_sources/non-integral            @input-output-hk/cardano-ledger 
+_sources/plutus-preprocessor     @input-output-hk/cardano-ledger 
+_sources/set-algebra             @input-output-hk/cardano-ledger 
+_sources/small-steps             @input-output-hk/cardano-ledger 
+_sources/small-steps-test        @input-output-hk/cardano-ledger 
+
+## Eras
+_sources/cardano-ledger-alonzo          @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-alonzo-test     @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-babbage         @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-babbage-test    @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-byron           @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-byron-test      @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-conway          @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-conway-test     @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-shelley         @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-shelley-test    @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-shelley-ma      @input-output-hk/cardano-ledger 
+_sources/cardano-ledger-shelley-ma-test @input-output-hk/cardano-ledger 
+
+# ouroboros-network
+
+## Network
+_sources/io-sim                             @input-output-hk/network-superowners
+_sources/io-sim-classes                     @input-output-hk/network-superowners
+_sources/network-mux                        @input-output-hk/network-superowners
+_sources/ntp-client                         @input-output-hk/network-superowners
+_sources/typed-protocols                    @input-output-hk/network-superowners
+_sources/typed-protocols-examples           @input-output-hk/network-superowners
+_sources/Win32-network                      @input-output-hk/network-superowners
+_sources/ouroboros-network-framework        @input-output-hk/network-superowners
+_sources/ouroboros-network                  @input-output-hk/network-superowners
+_sources/ouroboros-network/wireshark-plugin @input-output-hk/network-superowners
+_sources/ouroboros-network-testing          @input-output-hk/network-superowners
+_sources/cardano-client                     @input-output-hk/network-superowners
+
+## Consensus
+_sources/ouroboros-consensus/               @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-test/          @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-mock/          @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-mock-test/     @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-byron/         @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-byronspec/     @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-byron-test/    @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-shelley/       @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-shelley-test/  @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-cardano/       @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus-cardano-test/  @input-output-hk/consensus-superowners
+
+# plutus
+_sources/plutus-core                @input-output-hk/plutus
+_sources/plutus-ghc-stub            @input-output-hk/plutus
+_sources/plutus-ledger-api          @input-output-hk/plutus
+_sources/plutus-tx                  @input-output-hk/plutus
+_sources/plutus-tx-plugin           @input-output-hk/plutus
+_sources/prettyprinter-configurable @input-output-hk/plutus
+_sources/word-array                 @input-output-hk/plutus
+
+# Patched packages
+
+_sources/flat     @input-output-hk/plutus
+_sources/int-cast @input-output-hk/plutus
+_sources/moo      @input-output-hk/cardano-ledger
+# Need a node team
+# _sources/ekg-json   

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,45 +36,45 @@ _sources/cardano-ledger-shelley-ma-test @input-output-hk/cardano-ledger
 # ouroboros-network
 
 ## Network
-_sources/io-sim                             @input-output-hk/network-superowners
-_sources/io-sim-classes                     @input-output-hk/network-superowners
-_sources/network-mux                        @input-output-hk/network-superowners
-_sources/ntp-client                         @input-output-hk/network-superowners
-_sources/typed-protocols                    @input-output-hk/network-superowners
-_sources/typed-protocols-examples           @input-output-hk/network-superowners
-_sources/Win32-network                      @input-output-hk/network-superowners
-_sources/ouroboros-network-framework        @input-output-hk/network-superowners
-_sources/ouroboros-network                  @input-output-hk/network-superowners
-_sources/ouroboros-network/wireshark-plugin @input-output-hk/network-superowners
-_sources/ouroboros-network-testing          @input-output-hk/network-superowners
-_sources/cardano-client                     @input-output-hk/network-superowners
+_sources/io-sim                             @input-output-hk/ouroboros-networking
+_sources/io-sim-classes                     @input-output-hk/ouroboros-networking
+_sources/network-mux                        @input-output-hk/ouroboros-networking
+_sources/ntp-client                         @input-output-hk/ouroboros-networking
+_sources/typed-protocols                    @input-output-hk/ouroboros-networking
+_sources/typed-protocols-examples           @input-output-hk/ouroboros-networking
+_sources/Win32-network                      @input-output-hk/ouroboros-networking
+_sources/ouroboros-network-framework        @input-output-hk/ouroboros-networking
+_sources/ouroboros-network                  @input-output-hk/ouroboros-networking
+_sources/ouroboros-network/wireshark-plugin @input-output-hk/ouroboros-networking
+_sources/ouroboros-network-testing          @input-output-hk/ouroboros-networking
+_sources/cardano-client                     @input-output-hk/ouroboros-networking
 
 ## Consensus
-_sources/ouroboros-consensus/               @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-test/          @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-mock/          @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-mock-test/     @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-byron/         @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-byronspec/     @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-byron-test/    @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-shelley/       @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-shelley-test/  @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-cardano/       @input-output-hk/consensus-superowners
-_sources/ouroboros-consensus-cardano-test/  @input-output-hk/consensus-superowners
+_sources/ouroboros-consensus/               @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-test/          @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-mock/          @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-mock-test/     @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-byron/         @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-byronspec/     @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-byron-test/    @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-shelley/       @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-shelley-test/  @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-cardano/       @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-cardano-test/  @input-output-hk/ouroboros-consensus
 
 # plutus
-_sources/plutus-core                @input-output-hk/plutus
-_sources/plutus-ghc-stub            @input-output-hk/plutus
-_sources/plutus-ledger-api          @input-output-hk/plutus
-_sources/plutus-tx                  @input-output-hk/plutus
-_sources/plutus-tx-plugin           @input-output-hk/plutus
-_sources/prettyprinter-configurable @input-output-hk/plutus
-_sources/word-array                 @input-output-hk/plutus
+_sources/plutus-core                @input-output-hk/plutus-core
+_sources/plutus-ghc-stub            @input-output-hk/plutus-core
+_sources/plutus-ledger-api          @input-output-hk/plutus-core
+_sources/plutus-tx                  @input-output-hk/plutus-core
+_sources/plutus-tx-plugin           @input-output-hk/plutus-core
+_sources/prettyprinter-configurable @input-output-hk/plutus-core
+_sources/word-array                 @input-output-hk/plutus-core
 
 # Patched packages
 
-_sources/flat     @input-output-hk/plutus
-_sources/int-cast @input-output-hk/plutus
+_sources/flat     @input-output-hk/plutus-core
+_sources/int-cast @input-output-hk/plutus-core
 _sources/moo      @input-output-hk/cardano-ledger
 # Need a node team
 # _sources/ekg-json   

--- a/README.md
+++ b/README.md
@@ -274,6 +274,16 @@ The thing to avoid is to have the same package _version_ in both repositories.
 The simplest solution is to just make sure to use a higher major version number when you start releasing to Hackage, even if this looks a bit odd.
 For example, if CHaP contains `X-1.0` and `X-1.1`, then the first Hackage release should be `X-1.2` or `X-2.0`.
 
+## Access control for CHaP
+
+Since packages are released to CHaP simply by making PRs, CHaP uses `CODEOWNERS` to determine whose approval is needed to release a package. 
+The general rules are:
+- If a package is clearly owned by a particular team, then set that team as the CODEOWNER.
+- Prefer to use GitHub teams over individual accounts wherever possible.
+- In the case of patched packages, the owner should be whichever team owns the package that causes the dependency on the package that needs patching.
+
+Generally, use your judgement about what's appropriate.
+
 ## CI for CHaP
 
 The CI for CHaP does the following things:


### PR DESCRIPTION
I think this is a reasonably sane way to do access control. As a trial, I'm just going to set it up to request reviews from the listed people, but not to require them. We may want to make it a requirement in future.

Thus far I've added what I think is correct for `plutus`, `ledger`, `ouroboros-consensus`, and the patched pacakges. I don't know who or what to put for `cardano-node`, ideally there would be a team (Jordan?).

It would be great to find people for the other repositories in here.

I've also added some commentary to the README suggesting when people should add themselves to CODEOWNERS.

Work towards #33.

@disassembler maybe the release team should also be listed everywhere?
@coot I added the teams that are listed in the `ouroboros-network` CODEOWNERS but I can't find them anywhere and I can't give them write access here, so I think what's there currently won't work.