### PR TITLE
Add hydra-cardano-api 0.8.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,6 +71,9 @@ _sources/plutus-tx-plugin           @input-output-hk/plutus-core
 _sources/prettyprinter-configurable @input-output-hk/plutus-core
 _sources/word-array                 @input-output-hk/plutus-core
 
+# hydra
+_sources/hydra-* @input-output-hk/hydra-engineering
+
 # Patched packages
 
 _sources/flat     @input-output-hk/plutus-core

--- a/_sources/hydra-cardano-api/0.8.0/meta.toml
+++ b/_sources/hydra-cardano-api/0.8.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-11-16T08:13:53Z
+github = { repo = "input-output-hk/hydra-poc", rev = "d4f242b68069765117e7c615101df17708de40a2" }
+subdir = 'hydra-cardano-api'


### PR DESCRIPTION
Basically the same as https://github.com/input-output-hk/cardano-haskell-packages/pull/65, but this time the `cardano-api` is on CHaP and this is buildable without any `source-repository-package`s.
