### PR TITLE
ouroboros-network-0.3.0.0

### DIFF
--- a/_sources/ouroboros-consensus/0.1.0.3/meta.toml
+++ b/_sources/ouroboros-consensus/0.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-11-23T18:31:59Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "926d785efb6686ee46356cf6304c688a56e1493d" }
+subdir = 'ouroboros-consensus'

--- a/_sources/ouroboros-network/0.3.0.0/meta.toml
+++ b/_sources/ouroboros-network/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2022-11-23T18:31:59Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "926d785efb6686ee46356cf6304c688a56e1493d" }
+subdir = 'ouroboros-network'


### PR DESCRIPTION
For `cardano-node-1.35.5` release.

- Added ouroboros-network-0.3.0.0
- Added ouroboros-consensus-0.1.0.3
