### PR TITLE
Script for extracting version information from CHaP package dependencies of a project

### DIFF
--- a/scripts/version-lookup.sh
+++ b/scripts/version-lookup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+BASE_DIR=$(dirname $SCRIPT_DIR)
+
+versions() {
+  cat dist-newstyle/cache/plan.json \
+    | jq -r '
+      ."install-plan"[]
+      | select(."pkg-src".repo.uri == "https://input-output-hk.github.io/cardano-haskell-packages")
+      | {"pkg-name": ."pkg-name", "pkg-version": ."pkg-version"}
+      | @base64' \
+    | sort \
+    | uniq
+}
+
+for x in $(versions); do
+  pkg_json="$(echo "\"$x\""  | jq -r '@base64d')"
+  pkg_name="$(echo "$pkg_json" | jq -r '."pkg-name"')"
+  pkg_version="$(echo "$pkg_json" | jq -r '."pkg-version"')"
+  cat "$BASE_DIR/_sources/$pkg_name/$pkg_version/meta.toml" | yj -tj | jq "{\"root\": (. + {\"package\": {\"name\": \"$pkg_name\", \"version\": \"$pkg_version\"}})}"
+done | jq -n '.root = [inputs.root] | .root'


### PR DESCRIPTION
The following command extracts version information of CHaP dependencies for a project as a JSON file.  The `plan.json` for the project must have already been generated.

```
cardano-node $ ../cardano-haskell-packages/scripts/version-lookup.sh
[
  {
    "timestamp": "2022-10-17T00:00:00Z",
    "github": {
      "repo": "input-output-hk/Win32-network",
      "rev": "3825d3abf75f83f406c1f7161883c438dac7277d"
    },
    "package": {
      "name": "Win32-network",
      "version": "0.1.0.0"
    }
  },
...
  {
    "timestamp": "2022-10-17T00:00:00Z",
    "github": {
      "repo": "input-output-hk/plutus",
      "rev": "a56c96598b4b25c9e28215214d25189331087244"
    },
    "subdir": "word-array",
    "package": {
      "name": "word-array",
      "version": "0.1.0.0"
    }
  }
]
```

Requires `yq` and `yj` to be installed.