### PR TITLE
Only trigger the CI workflow on push if the push is to master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,14 @@
 name: CI
 
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  # Following https://github.com/orgs/community/discussions/26276
+  # to get builds on PRs and pushes to master but not double
+  # builds on PRs.
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
This seems to be the way to avoid getting double workflow runs on PRs
while still getting the other behaviour we want.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
