### PR TITLE
Release ouroboros-consensus 0.2.0.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -57,16 +57,19 @@ _sources/cardano-client                     @input-output-hk/ouroboros-networkin
 
 ## Consensus
 _sources/ouroboros-consensus/               @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-diffusion/     @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-test/          @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-mock/          @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-mock-test/     @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-byron/         @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-byronspec/     @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-byron-test/    @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-protocol/      @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-shelley/       @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-shelley-test/  @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-cardano/       @input-output-hk/ouroboros-consensus
 _sources/ouroboros-consensus-cardano-test/  @input-output-hk/ouroboros-consensus
+_sources/ouroboros-consensus-cardano-tools/ @input-output-hk/ouroboros-consensus
 
 # plutus
 _sources/plutus-core                @input-output-hk/plutus-core

--- a/_sources/ouroboros-consensus-byron-test/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron-test/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-byron-test'

--- a/_sources/ouroboros-consensus-byron/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-byron'

--- a/_sources/ouroboros-consensus-byronspec/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byronspec/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-byronspec'

--- a/_sources/ouroboros-consensus-cardano-test/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano-test/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-cardano-test'

--- a/_sources/ouroboros-consensus-cardano-tools/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano-tools/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-cardano-tools'

--- a/_sources/ouroboros-consensus-diffusion/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-mock-test/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-mock-test/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-mock-test'

--- a/_sources/ouroboros-consensus-mock/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-mock/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-mock'

--- a/_sources/ouroboros-consensus-protocol/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus-shelley-test/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-shelley-test/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-shelley-test'

--- a/_sources/ouroboros-consensus-shelley/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-shelley'

--- a/_sources/ouroboros-consensus-test/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-test/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus-test'

--- a/_sources/ouroboros-consensus/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-11T17:00:00Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
+subdir = 'ouroboros-consensus'


### PR DESCRIPTION
Tagging after the merge of [this PR](https://github.com/input-output-hk/ouroboros-network/pull/4353). See the [change](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus/CHANGELOG.md)[logs](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-consensus-cardano/CHANGELOG.md) for details.
