### PR TITLE
Added monoidal-synchronisation-0.1.0.2

### DIFF
--- a/_sources/monoidal-synchronisation/0.1.0.2/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-16T07:47:55Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "aff4ef4a043a70ceb38002f1c4ac57d729139350" }
+subdir = 'monoidal-synchronisation'


### PR DESCRIPTION
From https://github.com/input-output-hk/ouroboros-network at aff4ef4a043a70ceb38002f1c4ac57d729139350
