### PR TITLE
Bump foliage to support package metadata

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build repository (main)
         run: |
-          nix develop -c foliage build -j 0 --write-metadata
+          nix develop -c foliage build -j 0
           mv _repo _repo-main
 
       - name: Checkout tip commit

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build repository (main)
         run: |
-          nix develop -c foliage build -j 0
+          nix develop -c foliage build -j 0 --write-metadata
           mv _repo _repo-main
 
       - name: Checkout tip commit
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build repository (tip)
         run: |
-          nix develop -c foliage build -j 0
+          nix develop -c foliage build -j 0 --write-metadata
 
       - name: Copy static web assets
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675999288,
-        "narHash": "sha256-BBgEp/eyjDra+vEzyKi5CVl4MKMCePCaduPJtKZ7qgg=",
+        "lastModified": 1676949145,
+        "narHash": "sha256-7wtpDLP7qMhe1GcrMj5LWxWpIHwUAvprTYjvJvK+tjw=",
         "owner": "andreabedini",
         "repo": "foliage",
-        "rev": "f76eb918451ac275367a340fee86f4e7189314ee",
+        "rev": "dff438ee43fdd4f84b1029c334dc010b66cdbd3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump foliage to support package metadata. Passing to foliage the option `--write-metadata` makes foliage write out a file `_repo/foliage/packages.json` containing metadata about the package provenance. This can be used by downstream tools.

```
[
  {
    "pkg-name": "Win32-network",
    "pkg-version": "0.1.0.0",
    "timestamp": "2022-10-17T00:00:00Z",
    "url": "github:input-output-hk/Win32-network/3825d3abf75f83f406c1f7161883c438dac7277d"
  },
  {
    "pkg-name": "Win32-network",
    "pkg-version": "0.1.1.0",
    "timestamp": "2022-10-25T00:00:00Z",
    "url": "github:input-output-hk/Win32-network/4ed1f5dc22754e4e461cfc6901fd5eebe34541f4"
  },
  {
    "forced-version": true,
    "pkg-name": "Win32-network",
    "pkg-version": "0.1.1.1",
    "timestamp": "2023-01-03T09:34:24Z",
    "url": "github:input-output-hk/Win32-network/1521906427571afd64670c2ce5f074d36aefb636"
  },
...
```

@kosyrevSerge @michaelpj @jonathanknowles @angerman 
