### PR TITLE
cardano-base release

### DIFF
--- a/_sources/cardano-binary-test/1.4.0.0/meta.toml
+++ b/_sources/cardano-binary-test/1.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-binary/test'

--- a/_sources/cardano-binary/1.6.0.0/meta.toml
+++ b/_sources/cardano-binary/1.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-binary'

--- a/_sources/cardano-crypto-class/2.1.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-crypto-class'

--- a/_sources/cardano-crypto-praos/2.1.1.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-crypto-tests/2.1.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-crypto-tests'

--- a/_sources/cardano-strict-containers/0.1.2.0/meta.toml
+++ b/_sources/cardano-strict-containers/0.1.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-02-21T23:26:04Z
+github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
+subdir = 'cardano-strict-containers'


### PR DESCRIPTION
This release includes:

* `cardano-crypto-praos-2.1.1.0`
* `cardano-crypto-tests-2.1.0.0`
* `cardano-crypto-class-2.1.0.0`
* `cardano-binary-1.6.0.0`
* `cardano-binary-test-1.4.0.0`
* `cardano-strict-containers-0.1.2.0`


Other packages from `cardano-base` repo have not changed since the last time a release was made from that repo.