### PR TITLE
Mention Haskell.nix parsing limitation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ index-state:
 Note that a second `index-state` stanza completely ovverides the first, so
 
 ```
-index-state: 2022-08-25T00:00:00Z
+index-state: 2022-12-31T00:00:00Z
 index-state: cardano-haskell-packages 2022-08-25T00:00:00Z
 ```
 
@@ -111,6 +111,19 @@ The exception is if you have a `source-repository-package` stanza which override
 of the packages in CHaP. Then cabal will rebuild them both. If this becomes a problem,
 you can consider adding the patched package to CHaP itself,
 see [below](#how-do-i-add-a-patched-versions-of-a-hackage-package-to-chap).
+
+Warning: Haskell.nix cannot parse the `index-state` syntax with multiple
+repositories (see [haskell.nix#1869](https://github.com/input-output-hk/haskell.nix/issues/1869)).
+You can use the following workaround to appease both Haskell.nix and cabal.
+
+```
+-- haskell.nix will parse this (https://github.com/input-output-hk/haskell.nix/issues/1869)
+index-state: 2022-12-31T00:00:00Z
+-- cabal will overwrite the above with this
+index-state:
+  , hackage.haskell.org      2022-12-31T00:00:00Z
+  , cardano-haskell-packages 2022-08-25T00:00:00Z
+```
 
 ## Requirements for including a package in CHaP
 


### PR DESCRIPTION
This adds the haskell.nix parsing workaround to the README. See https://github.com/input-output-hk/haskell.nix/issues/1869 for the haskell.nix issue.