### PR TITLE
Add some of plutus-apps packages

### DIFF
--- a/_sources/freer-extras/1.2.0.0/meta.toml
+++ b/_sources/freer-extras/1.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-03-10T07:05:55Z
 github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
 subdir = 'freer-extras'
+
+[[revisions]]
+  number = 1
+  timestamp = 2023-03-13T06:49:06+00:00

--- a/_sources/freer-extras/1.2.0.0/meta.toml
+++ b/_sources/freer-extras/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-03-10T07:05:55Z
+github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
+subdir = 'freer-extras'

--- a/_sources/freer-extras/1.2.0.0/revisions/1.cabal
+++ b/_sources/freer-extras/1.2.0.0/revisions/1.cabal
@@ -1,0 +1,112 @@
+cabal-version: 2.2
+name:          freer-extras
+version:       1.2.0.0
+synopsis:      Useful extensions to simple-freer
+description:
+  freer-extras provides logging and monitoring functions extending simple-freer
+
+bug-reports:   https://github.com/input-output-hk/plutus-apps/issues
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Tobias Pflug
+maintainer:    tobias.pflug@iohk.io
+build-type:    Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/plutus-apps
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    ExplicitForAll
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities
+
+library
+  import:          lang
+  hs-source-dirs:  src
+  exposed-modules:
+    Control.Monad.Freer.Extras
+    Control.Monad.Freer.Extras.Beam
+    Control.Monad.Freer.Extras.Beam.Effects
+    Control.Monad.Freer.Extras.Beam.Postgres
+    Control.Monad.Freer.Extras.Beam.Sqlite
+    Control.Monad.Freer.Extras.Log
+    Control.Monad.Freer.Extras.Modify
+    Control.Monad.Freer.Extras.Pagination
+    Control.Monad.Freer.Extras.State
+    Control.Monad.Freer.Extras.Stream
+
+  other-modules:   Control.Monad.Freer.Extras.Beam.Common
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:   iohk-monitoring
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , aeson             ^>=2.0.1.0
+    , base               >=4.7 && <5
+    , beam-core         ^>=0.10.0.0
+    , beam-postgres     ^>=0.5.3.0
+    , beam-sqlite       ^>=0.5.2.0
+    , containers        ^>=0.6.5.1
+    , data-default      ^>=0.7.1.1
+    , freer-simple      ^>=1.2.1.2
+    , lens              ^>=5.2.1
+    , mtl               ^>=2.2.2
+    , postgresql-simple ^>=0.6.5
+    , prettyprinter     ^>=1.7.1
+    , resource-pool     ^>=0.4.0.0
+    , sqlite-simple     ^>=0.4.18.2
+    , streaming         ^>=0.2.3.1
+    , text              ^>=1.2.4.1
+
+test-suite freer-extras-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: test
+  other-modules:
+    Control.Monad.Freer.Extras.BeamSpec
+    Control.Monad.Freer.Extras.PaginationSpec
+
+  ----------------------------
+  -- Local components
+  ----------------------------
+  build-depends:  freer-extras >=1.2.0
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , base            >=4.7 && <5
+    , beam-core
+    , beam-migrate
+    , beam-sqlite
+    , containers
+    , contra-tracer
+    , freer-simple
+    , hedgehog
+    , lens
+    , resource-pool
+    , semigroups
+    , sqlite-simple
+    , tasty
+    , tasty-hedgehog1

--- a/_sources/freer-extras/1.2.0.0/revisions/1.cabal
+++ b/_sources/freer-extras/1.2.0.0/revisions/1.cabal
@@ -55,7 +55,7 @@ library
   --------------------------
   -- Other IOG dependencies
   --------------------------
-  build-depends:   iohk-monitoring
+  build-depends:   iohk-monitoring ^>=0.1.11.1
 
   ------------------------
   -- Non-IOG dependencies

--- a/_sources/plutus-ledger/1.2.0.0/meta.toml
+++ b/_sources/plutus-ledger/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-03-10T07:05:55Z
+github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
+subdir = 'plutus-ledger'

--- a/_sources/plutus-ledger/1.2.0.0/meta.toml
+++ b/_sources/plutus-ledger/1.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-03-10T07:05:55Z
 github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
 subdir = 'plutus-ledger'
+
+[[revisions]]
+  number = 1
+  timestamp = 2023-03-13T07:04:28+00:00

--- a/_sources/plutus-ledger/1.2.0.0/revisions/1.cabal
+++ b/_sources/plutus-ledger/1.2.0.0/revisions/1.cabal
@@ -1,0 +1,212 @@
+cabal-version:   3.0
+name:            plutus-ledger
+version:         1.2.0.0
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:      michael.peyton-jones@iohk.io
+author:          Michael Peyton Jones, Jann Mueller
+synopsis:        Wallet API
+description:     Plutus ledger library
+category:        Language
+build-type:      Simple
+extra-doc-files: README.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/plutus-apps
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    MultiParamTypeClasses
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  -- See Plutus Tx readme for why we need the following flags:
+  -- -fobject-code -fno-ignore-interface-pragmas and -fno-omit-interface-pragmas
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities -fobject-code
+    -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+
+flag defer-plugin-errors
+  description:
+    Defer errors from the plugin, useful for things like Haddock that can't handle it.
+
+  default:     False
+  manual:      True
+
+library
+  import:             lang
+  hs-source-dirs:     src
+  default-language:   Haskell2010
+  exposed-modules:
+    Data.Aeson.Extras
+    Data.Time.Units.Extra
+    Ledger
+    Ledger.Address
+    Ledger.Address.Orphans
+    Ledger.AddressMap
+    Ledger.Blockchain
+    Ledger.Builtins.Orphans
+    Ledger.CardanoWallet
+    Ledger.Contexts.Orphans
+    Ledger.Credential.Orphans
+    Ledger.Crypto
+    Ledger.Crypto.Orphans
+    Ledger.DCert.Orphans
+    Ledger.Index
+    Ledger.Index.Internal
+    Ledger.Orphans
+    Ledger.Scripts
+    Ledger.Scripts.Orphans
+    Ledger.Slot
+    Ledger.Test
+    Ledger.Tokens
+    Ledger.Tx
+    Ledger.Tx.CardanoAPI
+    Ledger.Tx.CardanoAPI.Internal
+    Ledger.Tx.Internal
+    Ledger.Tx.Orphans
+    Ledger.Tx.Orphans.V1
+    Ledger.Tx.Orphans.V2
+    Ledger.Typed.Scripts
+    Ledger.Typed.Scripts.Orphans
+    Ledger.Typed.Scripts.Validators
+    Ledger.Typed.Tx
+    Ledger.Typed.TypeUtils
+    Ledger.Value.CardanoAPI
+    Ledger.Value.Orphans
+    Prettyprinter.Extras
+
+  reexported-modules:
+    Plutus.V1.Ledger.Bytes as Ledger.Bytes,
+    Plutus.V1.Ledger.Credential as Ledger.Credential,
+    Plutus.V1.Ledger.DCert as Ledger.DCert,
+    Plutus.V1.Ledger.Interval as Ledger.Interval,
+    Plutus.V1.Ledger.Time as Ledger.Time,
+
+  -- The rest of the plutus-ledger-api modules are reexported from within
+  -- the Haskell modules and not in the current cabal file.
+  -- For example: Plutus.V1.Ledger.Address is reexported by Ledger.Address
+  other-modules:
+    Codec.CBOR.Extras
+    Ledger.Tx.CardanoAPITemp
+
+  --------------------
+  -- Local components
+  --------------------
+  build-depends:      plutus-script-utils >=1.2.0
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:
+    , cardano-api                  >=1.35
+    , cardano-binary              ^>=1.5.0
+    , cardano-crypto              ^>=1.1.1
+    , cardano-crypto-class        ^>=2.0.0.0.1
+    , cardano-ledger-alonzo        ==0.1.0.0
+    , cardano-ledger-babbage       ==0.1.0.0
+    , cardano-ledger-byron         ==0.1.0.0
+    , cardano-ledger-core          ==0.1.0.0
+    , cardano-ledger-shelley       ==0.1.0.0
+    , cardano-ledger-shelley-ma    ==0.1.0.0
+    , cardano-slotting            ^>=0.1.0.2
+    , iohk-monitoring             ^>=0.1.11.1
+    , ouroboros-consensus-shelley ^>=0.1.0.1
+    , plutus-core                  >=1.0.0
+    , plutus-ledger-api            >=1.0.0
+    , plutus-tx                    >=1.0.0
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  -- TODO: remove the contractmodel dependency once the dependency on cardano-node
+  -- has been bumped to include the instance of Ord for AddressInEra
+  -- defined there.
+  build-depends:
+    , aeson                    ^>=2.0.3.0
+    , base                      >=4.9  && <5
+    , base16-bytestring        ^>=1.0.2.0
+    , bytestring               ^>=0.10.12.0
+    , cborg                    ^>=0.2.8
+    , containers               ^>=0.6.5.1
+    , cryptonite                >=0.25 && <0.28
+    , flat                     ^>=0.4.4.0.0.0.0.2
+    , hashable                 ^>=1.3.5.0
+    , http-api-data            ^>=0.5
+    , lens                     ^>=5.2.1
+    , memory                   ^>=0.18.0
+    , mtl                      ^>=2.2.2
+    , newtype-generics         ^>=0.6.2
+    , prettyprinter            ^>=1.7.1
+    , quickcheck-contractmodel ^>=0.1.2.0
+    , scientific               ^>=0.3.7.0
+    , serialise                ^>=0.2.6.0
+    , servant                  ^>=0.19.1
+    , strict-containers        ^>=0.1.0.0
+    , tagged                   ^>=0.8.7
+    , template-haskell         ^>=2.16.0.0
+    , text                     ^>=1.2.4.1
+    , time-units               ^>=1.0.0
+    , transformers             ^>=0.5.6.2
+    , vector                   ^>=0.12.3.1
+
+  ghc-options:        -fprint-potential-instances
+
+  if !(impl(ghcjs) || os(ghcjs))
+    build-depends: plutus-tx-plugin >=1.0.0
+
+  if flag(defer-plugin-errors)
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+
+test-suite plutus-ledger-test
+  import:             lang
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  hs-source-dirs:     test
+  default-language:   Haskell2010
+  default-extensions: ImportQualifiedPost
+  other-modules:      Ledger.Tx.CardanoAPISpec
+
+  --------------------
+  -- Local components
+  --------------------
+  build-depends:
+    , plutus-ledger        >=1.2.0
+    , plutus-script-utils  >=1.2.0
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:
+    , cardano-api:{cardano-api, gen}  >=1.35
+    , cardano-crypto-class            >=2.0.0
+    , plutus-ledger-api               >=1.0.0
+    , plutus-tx                       >=1.0.0
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , aeson
+    , base            >=4.9 && <5
+    , bytestring
+    , hedgehog
+    , tasty
+    , tasty-hedgehog
+    , tasty-hunit

--- a/_sources/plutus-script-utils/1.2.0.0/meta.toml
+++ b/_sources/plutus-script-utils/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-03-10T07:05:55Z
+github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
+subdir = 'plutus-script-utils'

--- a/_sources/plutus-script-utils/1.2.0.0/meta.toml
+++ b/_sources/plutus-script-utils/1.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-03-10T07:05:55Z
 github = { repo = "input-output-hk/plutus-apps", rev = "c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb" }
 subdir = 'plutus-script-utils'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-13T07:15:21+00:00

--- a/_sources/plutus-script-utils/1.2.0.0/revisions/1.cabal
+++ b/_sources/plutus-script-utils/1.2.0.0/revisions/1.cabal
@@ -1,0 +1,126 @@
+cabal-version:   3.0
+name:            plutus-script-utils
+version:         1.2.0.0
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:      konstantinos.lambrou@iohk.io
+author:          Konstantinos Lambrou-Latreille
+homepage:        https://github.com/input-output-hk/plutus-apps#readme
+bug-reports:     https://github.com/input-output-hk/plutus-apps/issues
+synopsis:        Helper/utility functions for writing Plutus scripts.
+description:     Helper/utility functions for writing Plutus scripts.
+category:        Language
+build-type:      Simple
+extra-doc-files: README.adoc
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/plutus-apps
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    MultiParamTypeClasses
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  -- See Plutus Tx readme for why we need the following flags:
+  -- -fobject-code -fno-ignore-interface-pragmas and -fno-omit-interface-pragmas
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities -Wmissing-import-lists
+    -fobject-code -fno-ignore-interface-pragmas
+    -fno-omit-interface-pragmas
+
+flag defer-plugin-errors
+  description:
+    Defer errors from the plugin, useful for things like Haddock that can't handle it.
+
+  default:     False
+  manual:      True
+
+library
+  import:           lang
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  exposed-modules:
+    Plutus.Script.Utils.Ada
+    Plutus.Script.Utils.Scripts
+    Plutus.Script.Utils.Typed
+    Plutus.Script.Utils.V1.Address
+    Plutus.Script.Utils.V1.Contexts
+    Plutus.Script.Utils.V1.Generators
+    Plutus.Script.Utils.V1.Scripts
+    Plutus.Script.Utils.V1.Tx
+    Plutus.Script.Utils.V1.Typed.Scripts
+    Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies
+    Plutus.Script.Utils.V1.Typed.Scripts.StakeValidators
+    Plutus.Script.Utils.V1.Typed.Scripts.Validators
+    Plutus.Script.Utils.V2.Address
+    Plutus.Script.Utils.V2.Contexts
+    Plutus.Script.Utils.V2.Generators
+    Plutus.Script.Utils.V2.Scripts
+    Plutus.Script.Utils.V2.Tx
+    Plutus.Script.Utils.V2.Typed.Scripts
+    Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies
+    Plutus.Script.Utils.V2.Typed.Scripts.StakeValidators
+    Plutus.Script.Utils.V2.Typed.Scripts.Validators
+    Plutus.Script.Utils.Value
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:
+    , cardano-api            >=1.35
+    , cardano-ledger-alonzo ^>=0.1.0.0
+    , plutus-core            >=1.0.0
+    , plutus-ledger-api      >=1.0.0
+    , plutus-tx              >=1.0.0
+    , plutus-tx-plugin       >=1.0.0
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , aeson         ^>=2.0.1.0 && <2.2
+    , base           >=4.9 && <5
+    , bytestring    ^>=0.10.12.0
+    , mtl           ^>=2.2.2
+    , prettyprinter ^>=1.7.1
+    , serialise     ^>=0.2.6.0
+    , tagged        ^>=0.8.7
+    , text          ^>=1.2.4.1
+
+  -- TODO This needs to be changed to 1.35 once cardano-node creates the tag
+  ghc-options:      -fprint-potential-instances
+
+  if flag(defer-plugin-errors)
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+
+test-suite plutus-ledger-test
+  import:             lang
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  hs-source-dirs:     test
+  default-language:   Haskell2010
+  default-extensions: ImportQualifiedPost
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , base   >=4.9 && <5
+    , tasty


### PR DESCRIPTION
This adds

* plutus-ledger-1.2.0.0
* plutus-script-utils-1.2.0.0
* freer-extras-1.2.0.0

From the commit hash https://github.com/input-output-hk/plutus-apps/commit/c4f4dc5fedd5b1804781abb7db0fb5a553e24ecb. Note this is not identical to the [1.2.0.0 release](https://github.com/input-output-hk/plutus-apps/releases/tag/v1.2.0), since unfortunately that release refers to `quickcheck-contractmodel` with the old name `contractmodel`. The only difference between the two commits is in plutus-ledger cabal file, which changes its dependency from contract-model to quickcheck-contractmodel.

```
diff --git a/plutus-ledger/plutus-ledger.cabal b/plutus-ledger/plutus-ledger.cabal
index b2426cdfc..3e9c4e46f 100644
--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -140,13 +140,12 @@ library
   -- defined there.
   build-depends:
     , aeson
-    , base               >=4.9  && <5
+    , base                      >=4.9  && <5
     , base16-bytestring
     , bytestring
     , cborg
     , containers
-    , contractmodel
-    , cryptonite         >=0.25
+    , cryptonite                >=0.25
     , flat
     , hashable
     , http-api-data
@@ -155,6 +154,7 @@ library
     , mtl
     , newtype-generics
     , prettyprinter
+    , quickcheck-contractmodel
     , scientific
     , serialise
     , servant
```

These three packages seem to compile with the following configuration (one day we will fix this!).

```
allow-newer:
  -- cardano-ledger packages need aeson >2, the following packages have a
  -- too restictive upper bounds on aeson, so we relax them here. The hackage
  -- trustees can make a revision to these packages cabal file to solve the
  -- issue permanently.
  , ekg:aeson

constraints:
  , cardano-api==1.35.4
  , cardano-ledger-alonzo==0.1.0.0
  , cardano-ledger-babbage==0.1.0.0
  , cardano-ledger-byron==0.1.0.0
  , cardano-ledger-core==0.1.0.0
  , cardano-ledger-shelley==0.1.0.0
  , cardano-ledger-shelley-ma==0.1.0.0

  -- cardano-prelude-0.1.0.0 needs
  , protolude <0.3.1

  -- cardano-ledger-byron-0.1.0.0 needs
  , cardano-binary <1.5.0.1

  -- plutus-core-1.0.0.1 needs
  , cardano-crypto-class >2.0.0.0
  , algebraic-graphs <0.7

  -- cardano-ledger-core-0.1.0.0 needs
  , cardano-crypto-class <2.0.0.1

  -- cardano-crypto-class-2.0.0.0.1 needs
  , cardano-prelude <0.1.0.1

  -- ouroboros-consensus-shelley-0.1.0.1 needs
  , ouroboros-consensus-protocol==0.1.0.1

  -- the only cardano-crypto-wrapper that works in this context
  -- (cardano-crypto-wrapper-1.4.2 needs cardano-prelude >0.1.0.1)
  , cardano-crypto-wrapper==1.3.0

  -- cardano-ledger-conway-0.1.1.2 fails without this (despite it's not a
  -- direct dependency, likely it leaks through some ouroboros-consensus packages)
  , cardano-protocol-tpraos ==0.1.0.0

  -- cardano-ledger-shelley-0.1.0.0 needs
  , cardano-data ==0.1.0.0

  -- cardano-ledger-shelley-0.1.0.0 needs
  , vector-map ==0.1.0.0
```