### PR TITLE
Fix CI workflow to accept flake config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            substituters        = https://cache.iog.io https://cache.nixos.org https://foliage.cachix.org
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= foliage.cachix.org-1:kAFyYLnk8JcRURWReWZCatM9v3Rk24F5wNMpEj14Q/g=
+            accept-flake-config = true
 
       - name: Run checks
         run: nix develop -c ./scripts/check.sh
@@ -39,8 +38,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            substituters        = https://cache.iog.io https://cache.nixos.org https://foliage.cachix.org
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= foliage.cachix.org-1:kAFyYLnk8JcRURWReWZCatM9v3Rk24F5wNMpEj14Q/g=
+            accept-flake-config = true
 
       - name: Checkout main 
         uses: actions/checkout@v3


### PR DESCRIPTION
Rather than relying on the nix config settings. This is more robust and
also they were incomplete, so we were getting jobs hanging because
things weren't cached.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
