### PR TITLE
Add more smoke-tests packages up to cardano-node

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,6 +116,7 @@ jobs:
         uses: nixbuild/nixbuild-action@v16
         with:
           nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
+          generate_summary_for: 'job'
 
       - uses: actions/checkout@v3
 

--- a/_sources/byron-spec-chain/0.1.1.1/meta.toml
+++ b/_sources/byron-spec-chain/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'eras/byron/chain/executable-spec'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:36:24Z

--- a/_sources/byron-spec-chain/0.1.1.1/revisions/1.cabal
+++ b/_sources/byron-spec-chain/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,78 @@
+cabal-version: 2.2
+
+name:                byron-spec-chain
+version:             0.1.1.1
+synopsis:            Executable specification of the Cardano blockchain
+-- description:
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+-- copyright:
+category:            Testing
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Byron.Spec.Chain.STS.Block
+                     , Byron.Spec.Chain.STS.Rule.BBody
+                     , Byron.Spec.Chain.STS.Rule.Bupi
+                     , Byron.Spec.Chain.STS.Rule.Chain
+                     , Byron.Spec.Chain.STS.Rule.Epoch
+                     , Byron.Spec.Chain.STS.Rule.Pbft
+                     , Byron.Spec.Chain.STS.Rule.SigCnt
+
+  hs-source-dirs:      src
+  build-depends:       bimap >=0.4 && <0.5
+                     , bytestring
+                     , cardano-data
+                     , containers
+                     , byron-spec-ledger >= 0.1.1.1
+                     , goblins
+                     , hashable
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , microlens-th
+                     , small-steps
+                     , small-steps-test
+
+test-suite chain-rules-test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Test.Byron.Spec.Chain.STS.Properties
+                     , Test.Byron.AbstractSize.Properties
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       containers
+                     , cardano-data
+                     , data-ordlist
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-hunit
+                     -- local deps
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , small-steps
+                     , small-steps-test
+
+  -- See `byron-spec-ledger.cabal` for an explanation of the options below.
+  ghc-options:         "-with-rtsopts=-K4m -M300m"

--- a/_sources/byron-spec-chain/0.1.1.2/meta.toml
+++ b/_sources/byron-spec-chain/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/byron/chain/executable-spec'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:36:05Z

--- a/_sources/byron-spec-chain/0.1.1.2/revisions/1.cabal
+++ b/_sources/byron-spec-chain/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,78 @@
+cabal-version: 2.2
+
+name:                byron-spec-chain
+version:             0.1.1.2
+synopsis:            Executable specification of the Cardano blockchain
+-- description:
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+-- copyright:
+category:            Testing
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Byron.Spec.Chain.STS.Block
+                     , Byron.Spec.Chain.STS.Rule.BBody
+                     , Byron.Spec.Chain.STS.Rule.Bupi
+                     , Byron.Spec.Chain.STS.Rule.Chain
+                     , Byron.Spec.Chain.STS.Rule.Epoch
+                     , Byron.Spec.Chain.STS.Rule.Pbft
+                     , Byron.Spec.Chain.STS.Rule.SigCnt
+
+  hs-source-dirs:      src
+  build-depends:       bimap >=0.4 && <0.5
+                     , bytestring
+                     , cardano-data
+                     , containers
+                     , byron-spec-ledger >= 0.1.1.2
+                     , goblins
+                     , hashable
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , microlens-th
+                     , small-steps
+                     , small-steps-test
+
+test-suite chain-rules-test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Test.Byron.Spec.Chain.STS.Properties
+                     , Test.Byron.AbstractSize.Properties
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       containers
+                     , cardano-data
+                     , data-ordlist
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-hunit
+                     -- local deps
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , small-steps
+                     , small-steps-test
+
+  -- See `byron-spec-ledger.cabal` for an explanation of the options below.
+  ghc-options:         "-with-rtsopts=-K4m -M300m"

--- a/_sources/byron-spec-ledger/0.1.1.1/meta.toml
+++ b/_sources/byron-spec-ledger/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'eras/byron/ledger/executable-spec'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:35:27Z

--- a/_sources/byron-spec-ledger/0.1.1.1/revisions/1.cabal
+++ b/_sources/byron-spec-ledger/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,105 @@
+cabal-version: 2.2
+
+name:                byron-spec-ledger
+version:             0.1.1.1
+synopsis:            Executable specification of Cardano ledger
+-- description:
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+-- copyright:
+category:            Testing
+build-type:          Simple
+
+extra-source-files:  CHANGELOG.md
+                     src/goblin_genomes/*.genome
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wno-unused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:     Hedgehog.Gen.Double
+                     , Byron.Spec.Ledger.Core
+                     , Byron.Spec.Ledger.Core.Generators
+                     , Byron.Spec.Ledger.Core.Omniscient
+                     , Byron.Spec.Ledger.Delegation
+                     , Byron.Spec.Ledger.Delegation.Test
+                     , Byron.Spec.Ledger.GlobalParams
+                     , Byron.Spec.Ledger.Update
+                     , Byron.Spec.Ledger.Update.Generators
+                     , Byron.Spec.Ledger.Update.Test
+                     , Byron.Spec.Ledger.UTxO
+                     , Byron.Spec.Ledger.UTxO.Generators
+                     , Byron.Spec.Ledger.Util
+                     , Byron.Spec.Ledger.STS.UTXO
+                     , Byron.Spec.Ledger.STS.UTXOW
+                     , Byron.Spec.Ledger.STS.UTXOWS
+  build-depends:       bimap >=0.4 && <0.5
+                     , cardano-data
+                     , containers
+                     , filepath
+                     , goblins
+                     , hashable
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , microlens-th
+                     , nothunks
+                     , template-haskell
+                     , Unique >= 0.4.7.6
+                     -- IOHK deps
+                     , cardano-binary
+                     , cardano-prelude >= 0.1.0.1
+                     -- Local deps
+                     , small-steps
+                     , small-steps-test
+
+test-suite byron-spec-ledger-test
+  import:             base, project-config
+
+  hs-source-dirs: test
+  main-is: Main.hs
+  other-modules: Test.Byron.Spec.Ledger.Core.Generators.Properties
+               , Test.Byron.Spec.Ledger.Delegation.Examples
+               , Test.Byron.Spec.Ledger.Delegation.Properties
+               , Test.Byron.Spec.Ledger.AbstractSize.Properties
+               , Test.Byron.Spec.Ledger.Update.Examples
+               , Test.Byron.Spec.Ledger.Update.Properties
+               , Test.Byron.Spec.Ledger.Relation.Properties
+               , Test.Byron.Spec.Ledger.UTxO.Properties
+  type: exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends: bimap >=0.4 && <0.5
+               , cardano-data
+               , containers
+               , hedgehog >= 1.0.4
+               , microlens
+               , microlens-th
+               , tasty
+               , tasty-hunit
+               , tasty-hedgehog
+               , Unique >= 0.4.7.6
+               -- Local deps
+               , byron-spec-ledger
+               , small-steps
+               , small-steps-test
+
+  -- We set a bound here so that we're alerted of potential space
+  -- leaks in our generators (or test) code.
+  --
+  -- The 4 megabytes stack bound and 150 megabytes heap bound were
+  -- determined ad-hoc.
+  ghc-options:        "-with-rtsopts=-K4m -M150m"

--- a/_sources/byron-spec-ledger/0.1.1.2/meta.toml
+++ b/_sources/byron-spec-ledger/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/byron/ledger/executable-spec'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:34:09Z

--- a/_sources/byron-spec-ledger/0.1.1.2/revisions/1.cabal
+++ b/_sources/byron-spec-ledger/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,105 @@
+cabal-version: 2.2
+
+name:                byron-spec-ledger
+version:             0.1.1.2
+synopsis:            Executable specification of Cardano ledger
+-- description:
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+-- copyright:
+category:            Testing
+build-type:          Simple
+
+extra-source-files:  CHANGELOG.md
+                     src/goblin_genomes/*.genome
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wno-unused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:     Hedgehog.Gen.Double
+                     , Byron.Spec.Ledger.Core
+                     , Byron.Spec.Ledger.Core.Generators
+                     , Byron.Spec.Ledger.Core.Omniscient
+                     , Byron.Spec.Ledger.Delegation
+                     , Byron.Spec.Ledger.Delegation.Test
+                     , Byron.Spec.Ledger.GlobalParams
+                     , Byron.Spec.Ledger.Update
+                     , Byron.Spec.Ledger.Update.Generators
+                     , Byron.Spec.Ledger.Update.Test
+                     , Byron.Spec.Ledger.UTxO
+                     , Byron.Spec.Ledger.UTxO.Generators
+                     , Byron.Spec.Ledger.Util
+                     , Byron.Spec.Ledger.STS.UTXO
+                     , Byron.Spec.Ledger.STS.UTXOW
+                     , Byron.Spec.Ledger.STS.UTXOWS
+  build-depends:       bimap >=0.4 && <0.5
+                     , cardano-data
+                     , containers
+                     , filepath
+                     , goblins
+                     , hashable
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , microlens-th
+                     , nothunks
+                     , template-haskell
+                     , Unique >= 0.4.7.6
+                     -- IOHK deps
+                     , cardano-binary
+                     , cardano-prelude >= 0.1.0.1
+                     -- Local deps
+                     , small-steps
+                     , small-steps-test
+
+test-suite byron-spec-ledger-test
+  import:             base, project-config
+
+  hs-source-dirs: test
+  main-is: Main.hs
+  other-modules: Test.Byron.Spec.Ledger.Core.Generators.Properties
+               , Test.Byron.Spec.Ledger.Delegation.Examples
+               , Test.Byron.Spec.Ledger.Delegation.Properties
+               , Test.Byron.Spec.Ledger.AbstractSize.Properties
+               , Test.Byron.Spec.Ledger.Update.Examples
+               , Test.Byron.Spec.Ledger.Update.Properties
+               , Test.Byron.Spec.Ledger.Relation.Properties
+               , Test.Byron.Spec.Ledger.UTxO.Properties
+  type: exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends: bimap >=0.4 && <0.5
+               , cardano-data
+               , containers
+               , hedgehog >= 1.0.4
+               , microlens
+               , microlens-th
+               , tasty
+               , tasty-hunit
+               , tasty-hedgehog
+               , Unique >= 0.4.7.6
+               -- Local deps
+               , byron-spec-ledger
+               , small-steps
+               , small-steps-test
+
+  -- We set a bound here so that we're alerted of potential space
+  -- leaks in our generators (or test) code.
+  --
+  -- The 4 megabytes stack bound and 150 megabytes heap bound were
+  -- determined ad-hoc.
+  ghc-options:        "-with-rtsopts=-K4m -M150m"

--- a/_sources/cardano-api/1.35.4/meta.toml
+++ b/_sources/cardano-api/1.35.4/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-10T17:31:44Z
 github = { repo = "input-output-hk/cardano-node", rev = "ebc7be471b30e5931b35f9bbc236d21c375b91bb" }
 subdir = 'cardano-api'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:29:22Z

--- a/_sources/cardano-api/1.35.4/revisions/1.cabal
+++ b/_sources/cardano-api/1.35.4/revisions/1.cabal
@@ -1,0 +1,246 @@
+cabal-version: 3.0
+
+name:                   cardano-api
+version:                1.35.4
+description:            The cardano api
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     README.md, ChangeLog.md
+
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+common maybe-unix
+  if !os(windows)
+     build-depends:    unix
+
+library
+  import:               base, project-config, maybe-unix
+
+  hs-source-dirs:       src
+
+  exposed-modules:      Cardano.Api
+                        Cardano.Api.Byron
+                        Cardano.Api.ChainSync.Client
+                        Cardano.Api.ChainSync.ClientPipelined
+                        Cardano.Api.Crypto.Ed25519Bip32
+                        Cardano.Api.EraCast
+                        Cardano.Api.Protocol.Types
+                        Cardano.Api.Shelley
+                        -- TODO: Eliminate in the future when
+                        -- we create wrapper types for the ledger types
+                        -- in this module
+                        Cardano.Api.Orphans
+                        Cardano.Api.SerialiseTextEnvelope
+
+  other-modules:
+                        -- Splitting up the big Typed module:
+                        Cardano.Api.Address
+                        Cardano.Api.Block
+                        Cardano.Api.Certificate
+                        Cardano.Api.Convenience.Constraints
+                        Cardano.Api.Convenience.Construction
+                        Cardano.Api.Convenience.Query
+                        Cardano.Api.Environment
+                        Cardano.Api.Eras
+                        Cardano.Api.Error
+                        Cardano.Api.Fees
+                        Cardano.Api.GenesisParameters
+                        Cardano.Api.Hash
+                        Cardano.Api.HasTypeProxy
+                        Cardano.Api.IPC
+                        Cardano.Api.IPC.Monad
+                        Cardano.Api.InMode
+                        Cardano.Api.Json
+                        Cardano.Api.Key
+                        Cardano.Api.KeysByron
+                        Cardano.Api.KeysPraos
+                        Cardano.Api.KeysShelley
+                        Cardano.Api.LedgerEvent
+                        Cardano.Api.LedgerState
+                        Cardano.Api.Modes
+                        Cardano.Api.NetworkId
+                        Cardano.Api.OperationalCertificate
+                        Cardano.Api.ProtocolParameters
+                        Cardano.Api.Query
+                        Cardano.Api.Script
+                        Cardano.Api.ScriptData
+                        Cardano.Api.SerialiseBech32
+                        Cardano.Api.SerialiseCBOR
+                        Cardano.Api.SerialiseJSON
+                        Cardano.Api.SerialiseLedgerCddl
+                        Cardano.Api.SerialiseRaw
+                        Cardano.Api.SerialiseUsing
+                        Cardano.Api.Shelley.Genesis
+                        Cardano.Api.SpecialByron
+                        Cardano.Api.StakePoolMetadata
+                        Cardano.Api.Tx
+                        Cardano.Api.TxBody
+                        Cardano.Api.TxIn
+                        Cardano.Api.TxMetadata
+                        Cardano.Api.TxSubmit.ErrorRender
+                        Cardano.Api.TxSubmit.Types
+                        Cardano.Api.Utils
+                        Cardano.Api.Value
+                        Cardano.Api.ValueParser
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , aeson-pretty      >= 0.8.5
+                      , attoparsec
+                      , array
+                      , base16-bytestring >= 1.0
+                      , base58-bytestring
+                      , bech32 >= 1.1.0
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto
+                      , cardano-crypto-class
+                      , cardano-crypto-wrapper
+                      , cardano-data
+                      , cardano-ledger-alonzo < 0.1.1
+                      , cardano-ledger-babbage < 0.1.1
+                      , cardano-ledger-byron < 0.1.1
+                      , cardano-ledger-core < 0.1.1
+                      , cardano-ledger-shelley-ma < 0.1.1
+                      , cardano-prelude
+                      , cardano-protocol-tpraos
+                      , cardano-slotting
+                      , cborg
+                      , vector-map
+                      , contra-tracer
+                      , containers
+                      , cryptonite
+                      , deepseq
+                      , directory
+                      , filepath
+                      , formatting
+                      , iproute
+                      , memory
+                      , network
+                      , nothunks
+                      , optparse-applicative-fork
+                      , ouroboros-consensus <= 0.1.0.1
+                      , ouroboros-consensus-byron <= 0.1.0.1
+                      , ouroboros-consensus-cardano <= 0.1.0.1
+                      , ouroboros-consensus-protocol <= 0.1.0.1
+                      , ouroboros-consensus-shelley <= 0.1.0.1
+                      , ouroboros-network <= 0.1.0.1
+                      , ouroboros-network-framework <= 0.1.0.1
+                      , parsec
+                      , plutus-ledger-api < 1.1
+                      , prettyprinter
+                      , prettyprinter-configurable
+                      , scientific
+                      , serialise
+                      , small-steps
+                      , cardano-ledger-shelley < 0.2.0.0
+                      , small-steps
+                      , stm
+                      , strict-containers
+                      , text
+                      , time
+                      , transformers
+                      , transformers-except
+                      , typed-protocols
+                      , unordered-containers >= 0.2.11
+                      , vector
+                      , yaml
+
+library gen
+  import:               base, project-config
+
+  visibility:           public
+
+  hs-source-dirs:       gen
+
+  exposed-modules:      Gen.Cardano.Api
+                        Gen.Cardano.Api.Metadata
+                        Gen.Cardano.Api.Typed
+                        Gen.Cardano.Crypto.Seed
+                        Gen.Hedgehog.Roundtrip.Bech32
+                        Gen.Hedgehog.Roundtrip.CBOR
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , base16-bytestring
+                      , bytestring
+                      , cardano-api
+                      , cardano-binary
+                      , cardano-crypto-class
+                      , cardano-crypto-test
+                      , cardano-ledger-alonzo
+                      , cardano-ledger-byron-test
+                      , cardano-ledger-core
+                      , cardano-prelude
+                      , containers
+                      , hedgehog
+                      , plutus-core
+                      , cardano-ledger-shelley
+                      , text
+
+test-suite cardano-api-test
+  import:               base, project-config
+  hs-source-dirs:       test
+  main-is:              cardano-api-test.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , bytestring
+                      , cardano-api
+                      , cardano-api:gen
+                      , cardano-binary
+                      , cardano-crypto
+                      , cardano-crypto-class
+                      , cardano-crypto-test
+                      , cardano-crypto-tests
+                      , cardano-ledger-core
+                      , cardano-prelude
+                      , cardano-slotting
+                      , containers
+                      , hedgehog
+                      , hedgehog-extras
+                      , ouroboros-consensus
+                      , ouroboros-consensus-shelley
+                      , QuickCheck
+                      , cardano-ledger-shelley
+                      , cardano-ledger-shelley-test
+                      , tasty
+                      , tasty-hedgehog
+                      , tasty-quickcheck
+                      , tasty-th
+                      , time
+
+  other-modules:        Test.Cardano.Api.Crypto
+                        Test.Cardano.Api.Genesis
+                        Test.Cardano.Api.Json
+                        Test.Cardano.Api.KeysByron
+                        Test.Cardano.Api.Ledger
+                        Test.Cardano.Api.Metadata
+                        Test.Cardano.Api.Typed.Address
+                        Test.Cardano.Api.Typed.Bech32
+                        Test.Cardano.Api.Typed.CBOR
+                        Test.Cardano.Api.Typed.Envelope
+                        Test.Cardano.Api.Typed.JSON
+                        Test.Cardano.Api.Typed.Ord
+                        Test.Cardano.Api.Typed.Orphans
+                        Test.Cardano.Api.Typed.RawBytes
+                        Test.Cardano.Api.Typed.Script
+                        Test.Cardano.Api.Typed.TxBody
+                        Test.Cardano.Api.Typed.Value
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/_sources/cardano-crypto-class/2.1.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-21T23:26:04Z
 github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
 subdir = 'cardano-crypto-class'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:25:11Z

--- a/_sources/cardano-crypto-class/2.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-class/2.1.0.0/revisions/1.cabal
@@ -1,0 +1,147 @@
+cabal-version:      2.2
+name:               cardano-crypto-class
+version:            2.1.0.0
+synopsis:
+  Type classes abstracting over cryptography primitives for Cardano
+
+description:
+  Type classes abstracting over cryptography primitives for Cardano
+
+license:            Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+author:             IOHK
+maintainer:         operations@iohk.io
+copyright:          2019-2021 IOHK
+category:           Currency
+build-type:         Simple
+extra-source-files: README.md
+                    CHANGELOG.md
+
+flag development
+  description: Disable `-Werror`
+  default:     False
+  manual:      True
+
+flag secp256k1-support
+    description: Enable support for functions from libsecp256k1. Requires
+                 a recent libsecp256k1 with support for Schnorr signatures.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -Wunused-packages
+
+  if !flag(development)
+    ghc-options: -Werror
+
+library
+  import:            base, project-config
+  hs-source-dirs:    src
+  exposed-modules:
+    Cardano.Crypto.DSIGN
+    Cardano.Crypto.DSIGN.Class
+    Cardano.Crypto.DSIGN.Ed25519
+    Cardano.Crypto.DSIGN.Ed448
+    Cardano.Crypto.DSIGN.Mock
+    Cardano.Crypto.DSIGN.NeverUsed
+    Cardano.Crypto.Hash
+    Cardano.Crypto.Hash.Blake2b
+    Cardano.Crypto.Hash.Class
+    Cardano.Crypto.Hash.Keccak256
+    Cardano.Crypto.Hash.NeverUsed
+    Cardano.Crypto.Hash.SHA256
+    Cardano.Crypto.Hash.SHA3_256
+    Cardano.Crypto.Hash.Short
+    Cardano.Crypto.Init
+    Cardano.Crypto.KES
+    Cardano.Crypto.KES.Class
+    Cardano.Crypto.KES.CompactSingle
+    Cardano.Crypto.KES.CompactSum
+    Cardano.Crypto.KES.Mock
+    Cardano.Crypto.KES.NeverUsed
+    Cardano.Crypto.KES.Simple
+    Cardano.Crypto.KES.Single
+    Cardano.Crypto.KES.Sum
+    Cardano.Crypto.Libsodium
+    Cardano.Crypto.Libsodium.C
+    Cardano.Crypto.Libsodium.Constants
+    Cardano.Crypto.Libsodium.Hash
+    Cardano.Crypto.Libsodium.Init
+    Cardano.Crypto.Libsodium.Memory
+    Cardano.Crypto.Libsodium.Memory.Internal
+    Cardano.Crypto.Libsodium.MLockedBytes
+    Cardano.Crypto.Libsodium.MLockedBytes.Internal
+    Cardano.Crypto.Libsodium.UnsafeC
+    Cardano.Crypto.PinnedSizedBytes
+    Cardano.Crypto.Seed
+    Cardano.Crypto.Util
+    Cardano.Crypto.VRF
+    Cardano.Crypto.VRF.Class
+    Cardano.Crypto.VRF.Mock
+    Cardano.Crypto.VRF.NeverUsed
+    Cardano.Crypto.VRF.Simple
+    Cardano.Foreign
+
+  other-modules:
+    Cardano.Crypto.PackedBytes
+
+  build-depends:
+    , aeson
+    , base
+    , base16-bytestring  >=1
+    , bytestring
+    , cardano-binary >= 1.6
+    , cardano-strict-containers
+    , cryptonite
+    , deepseq
+    , heapwords
+    , memory
+    , nothunks
+    , primitive
+    , serialise
+    , template-haskell
+    , th-compat
+    , text
+    , transformers
+    , vector < 0.13
+
+  if impl(ghc < 9.0.0)
+    build-depends:
+      integer-gmp
+
+  pkgconfig-depends: libsodium -any
+
+  if flag(secp256k1-support)
+    exposed-modules:
+      Cardano.Crypto.DSIGN.EcdsaSecp256k1
+      Cardano.Crypto.DSIGN.SchnorrSecp256k1
+      Cardano.Crypto.SECP256K1.Constants
+      Cardano.Crypto.SECP256K1.C
+    pkgconfig-depends: libsecp256k1 -any
+    cpp-options: -DSECP256K1_ENABLED
+
+test-suite test-memory-example
+  import:         base, project-config
+  -- Temporarily removing this as it is breaking the CI, and
+  -- we don't see the benefit. Will circle back to this to decide
+  -- whether to modify or completely remove.
+  buildable:      False
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: memory-example
+  main-is:        Main.hs
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+
+  if (os(linux) || os(osx))
+    build-depends: unix

--- a/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:44:35Z

--- a/_sources/cardano-crypto-wrapper/1.3.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.3.0/revisions/1.cabal
@@ -1,0 +1,120 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.3.0
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary 
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary <= 1.5.0.0
+                     , cardano-crypto
+                     , cardano-prelude < 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , memory
+                     , mtl
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , hedgehog >= 1.0.4
+                     , memory
+                     , text
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-crypto-wrapper/1.4.1/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.4.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:33:01Z

--- a/_sources/cardano-crypto-wrapper/1.4.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.4.1/revisions/1.cabal
@@ -1,0 +1,141 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.4.1
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+data-files:          test/golden/AbstractHash
+                     test/golden/DecShare
+                     test/golden/EncShare
+                     test/golden/PassPhrase
+                     test/golden/RedeemSignature
+                     test/golden/RedeemSigningKey
+                     test/golden/RedeemVerificationKey
+                     test/golden/Secret
+                     test/golden/SecretProof
+                     test/golden/Signature
+                     test/golden/SigningKey
+                     test/golden/VerificationKey
+                     test/golden/VssPublicKey
+                     test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary
+                     , cardano-crypto
+                     , cardano-prelude >= 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , heapwords
+                     , memory
+                     , mtl
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+                       Paths_cardano_crypto_wrapper
+                       GetDataFileName
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , memory
+                     , text
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:32:34Z

--- a/_sources/cardano-crypto-wrapper/1.4.2/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.4.2/revisions/1.cabal
@@ -1,0 +1,139 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.4.2
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+data-files:          test/golden/AbstractHash
+                     test/golden/DecShare
+                     test/golden/EncShare
+                     test/golden/PassPhrase
+                     test/golden/RedeemSignature
+                     test/golden/RedeemSigningKey
+                     test/golden/RedeemVerificationKey
+                     test/golden/Secret
+                     test/golden/SecretProof
+                     test/golden/Signature
+                     test/golden/SigningKey
+                     test/golden/VerificationKey
+                     test/golden/VssPublicKey
+                     test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary
+                     , cardano-crypto
+                     , cardano-prelude >= 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , heapwords
+                     , memory
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+                       Paths_cardano_crypto_wrapper
+                       GetDataFileName
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , memory
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-ledger-alonzo/0.1.1.2/meta.toml
+++ b/_sources/cardano-ledger-alonzo/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/alonzo/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:30:30Z

--- a/_sources/cardano-ledger-alonzo/0.1.1.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-alonzo/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,96 @@
+cabal-version: 3.0
+
+name:                cardano-ledger-alonzo
+version:             0.1.1.2
+synopsis:            Cardano ledger introducing Plutus Core
+description:
+  This package builds upon the Mary ledger with support for extended UTxO
+  via Plutus Core.
+bug-reports:         https://github.com/input-output-hk/cardano-ledger/issues
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+copyright:           2020 Input Output (Hong Kong) Ltd.
+category:            Network
+build-type:          Simple
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   eras/alonzo/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wpartial-fields
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Alonzo
+    Cardano.Ledger.Alonzo.Data
+    Cardano.Ledger.Alonzo.Genesis
+    Cardano.Ledger.Alonzo.Language
+    Cardano.Ledger.Alonzo.PlutusScriptApi
+    Cardano.Ledger.Alonzo.PParams
+    Cardano.Ledger.Alonzo.Rules
+    Cardano.Ledger.Alonzo.Scripts
+    Cardano.Ledger.Alonzo.Tools
+    Cardano.Ledger.Alonzo.Translation
+    Cardano.Ledger.Alonzo.Tx
+    Cardano.Ledger.Alonzo.TxBody
+    Cardano.Ledger.Alonzo.TxInfo
+    Cardano.Ledger.Alonzo.TxSeq
+    Cardano.Ledger.Alonzo.TxWitness
+  other-modules:
+    Cardano.Ledger.Alonzo.Era
+    Cardano.Ledger.Alonzo.Rules.Bbody
+    Cardano.Ledger.Alonzo.Rules.Ledger
+    Cardano.Ledger.Alonzo.Rules.Utxo
+    Cardano.Ledger.Alonzo.Rules.Utxos
+    Cardano.Ledger.Alonzo.Rules.Utxow
+  build-depends:
+    aeson >= 2,
+    array,
+    base-deriving-via,
+    base64-bytestring,
+    bytestring,
+    cardano-binary,
+    cardano-data,
+    cardano-crypto-class,
+    cardano-ledger-core,
+    cardano-ledger-shelley-ma,
+    cardano-slotting,
+    containers,
+    data-default,
+    deepseq,
+    heapwords,
+    measures,
+    mtl,
+    microlens,
+    nothunks,
+    plutus-core,
+    plutus-ledger-api >= 1.1,
+    prettyprinter,
+    serialise,
+    set-algebra,
+    cardano-ledger-shelley,
+    scientific,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    utf8-string,
+    validation-selective,
+  hs-source-dirs:
+    src

--- a/_sources/cardano-ledger-byron-test/1.4.1/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.4.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'eras/byron/ledger/impl/test'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:38:16Z

--- a/_sources/cardano-ledger-byron-test/1.4.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron-test/1.4.1/revisions/1.cabal
@@ -1,0 +1,236 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-byron-test
+version:             1.4.1
+synopsis:            Test helpers from cardano-ledger exposed to other packages
+description:         Test helpers from cardano-ledger exposed to other packages
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:
+                       Test.Cardano.Chain.Block.CBOR
+                       Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Model
+                       Test.Cardano.Chain.Block.Model.Examples
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Block.ValidationMode
+
+                       Test.Cardano.Chain.Byron.API
+
+                       Test.Cardano.Chain.Buildable
+
+                       Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.CBOR
+                       Test.Cardano.Chain.Common.Compact
+                       Test.Cardano.Chain.Common.Example
+                       Test.Cardano.Chain.Common.Gen
+                       Test.Cardano.Chain.Common.Lovelace
+                       Test.Cardano.Chain.Config
+
+                       Test.Cardano.Chain.Delegation.CBOR
+                       Test.Cardano.Chain.Delegation.Certificate
+                       Test.Cardano.Chain.Delegation.Example
+                       Test.Cardano.Chain.Delegation.Gen
+                       Test.Cardano.Chain.Delegation.Model
+
+                       Test.Cardano.Chain.Elaboration.Block
+                       Test.Cardano.Chain.Elaboration.Delegation
+                       Test.Cardano.Chain.Elaboration.Keys
+                       Test.Cardano.Chain.Elaboration.Update
+                       Test.Cardano.Chain.Elaboration.UTxO
+
+                       Test.Cardano.Chain.Epoch.File
+
+                       Test.Cardano.Chain.Genesis.CBOR
+                       Test.Cardano.Chain.Genesis.Dummy
+                       Test.Cardano.Chain.Genesis.Example
+                       Test.Cardano.Chain.Genesis.Gen
+                       Test.Cardano.Chain.Genesis.Json
+
+                       Test.Cardano.Chain.MempoolPayload.CBOR
+                       Test.Cardano.Chain.MempoolPayload.Example
+                       Test.Cardano.Chain.MempoolPayload.Gen
+
+                       Test.Cardano.Chain.Ssc.CBOR
+
+                       Test.Cardano.Chain.Slotting.CBOR
+                       Test.Cardano.Chain.Slotting.Example
+                       Test.Cardano.Chain.Slotting.Gen
+                       Test.Cardano.Chain.Slotting.Properties
+
+                       Test.Cardano.Chain.UTxO.CBOR
+                       Test.Cardano.Chain.UTxO.Compact
+                       Test.Cardano.Chain.UTxO.Example
+                       Test.Cardano.Chain.UTxO.Gen
+                       Test.Cardano.Chain.UTxO.Model
+                       Test.Cardano.Chain.UTxO.ValidationMode
+
+                       Test.Cardano.Chain.Update.CBOR
+                       Test.Cardano.Chain.Update.Example
+                       Test.Cardano.Chain.Update.Gen
+                       Test.Cardano.Chain.Update.Properties
+
+                       Test.Cardano.Mirror
+
+                       Test.Options
+
+  other-modules:
+                       Paths_cardano_ledger_byron_test
+                       GetDataFileName
+  cpp-options:         -DCARDANO_LEDGER_BYRON_TEST
+  build-depends:       base16-bytestring >= 1
+                     , bimap
+                     , bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-ledger-byron
+                     , cardano-crypto
+                     , cardano-crypto-test
+                     , cardano-crypto-wrapper
+                     , cardano-prelude >= 0.1.0.1
+                     , cardano-prelude-test
+                     , containers
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , directory
+                     , filepath
+                     , formatting
+                     , generic-monoid
+                     , heapwords
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , resourcet
+                     , small-steps
+                     , small-steps-test
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+                     , text
+                     , time
+                     , vector
+
+data-files: golden/cbor/block/BlockSignature
+            golden/cbor/block/Body
+            golden/cbor/block/BoundaryBlockHeader
+            golden/cbor/block/BoundaryBody
+            golden/cbor/block/BoundaryConsensusData
+            golden/cbor/block/BoundaryProof
+            golden/cbor/block/ExtraBodyData
+            golden/cbor/block/Header
+            golden/cbor/block/HeaderHash
+            golden/cbor/block/Proof
+            golden/cbor/block/StaticConfig_GCSpec
+            golden/cbor/block/ToSign
+            golden/cbor/common/Address
+            golden/cbor/common/Address0
+            golden/cbor/common/Address1
+            golden/cbor/common/Address2
+            golden/cbor/common/Address3
+            golden/cbor/common/Address4
+            golden/cbor/common/AddrSpendingData_Redeem
+            golden/cbor/common/AddrSpendingData_VerKey
+            golden/cbor/common/AddrType_R
+            golden/cbor/common/AddrType_VK
+            golden/cbor/common/Attributes
+            golden/cbor/common/BlockCount
+            golden/cbor/common/ChainDifficulty
+            golden/cbor/common/KeyHash
+            golden/cbor/common/Lovelace
+            golden/cbor/common/LovelacePortion
+            golden/cbor/common/MerkleRoot
+            golden/cbor/common/MerkleTree
+            golden/cbor/common/TxFeePolicy_Linear
+            golden/cbor/common/TxSizeLinear
+            golden/cbor/delegation/Certificate
+            golden/cbor/delegation/DlgPayload
+            golden/cbor/mempoolpayload/MempoolPayload
+            golden/cbor/mempoolpayload/MempoolPayload1
+            golden/cbor/mempoolpayload/MempoolPayload2
+            golden/cbor/mempoolpayload/MempoolPayload3
+            golden/cbor/slotting/EpochAndSlotCount
+            golden/cbor/slotting/EpochNumber
+            golden/cbor/slotting/EpochSlots
+            golden/cbor/slotting/SlotNumber
+            golden/cbor/ssc/Commitment
+            golden/cbor/ssc/CommitmentsMap
+            golden/cbor/ssc/InnerSharesMap
+            golden/cbor/ssc/Opening
+            golden/cbor/ssc/OpeningsMap
+            golden/cbor/ssc/SharesMap
+            golden/cbor/ssc/SignedCommitment
+            golden/cbor/ssc/SscPayload_CertificatesPayload
+            golden/cbor/ssc/SscPayload_CommitmentsPayload
+            golden/cbor/ssc/SscPayload_OpeningsPayload
+            golden/cbor/ssc/SscPayload_SharesPayload
+            golden/cbor/ssc/SscProof_CertificatesProof
+            golden/cbor/ssc/SscProof_CommitmentsProof
+            golden/cbor/ssc/SscProof_OpeningsProof
+            golden/cbor/ssc/SscProof_SharesProof
+            golden/cbor/ssc/VssCertificate
+            golden/cbor/ssc/VssCertificatesHash
+            golden/cbor/ssc/VssCertificatesMap
+            golden/cbor/update/ApplicationName
+            golden/cbor/update/AttackTarget_NetworkAddressTarget
+            golden/cbor/update/AttackTarget_PubKeyAddressTarget
+            golden/cbor/update/BlockHeader_Boundary
+            golden/cbor/update/CommitmentSignature
+            golden/cbor/update/HashRaw
+            golden/cbor/update/HashTx
+            golden/cbor/update/InstallerHash
+            golden/cbor/update/Payload
+            golden/cbor/update/Proof
+            golden/cbor/update/Proposal
+            golden/cbor/update/ProposalBody
+            golden/cbor/update/ProtocolParameters
+            golden/cbor/update/ProtocolParametersUpdate
+            golden/cbor/update/ProtocolVersion
+            golden/cbor/update/SharesDistribution
+            golden/cbor/update/SoftforkRule
+            golden/cbor/update/SoftwareVersion
+            golden/cbor/update/StaticConfig_GCSpec
+            golden/cbor/update/StaticConfig_GCSrc
+            golden/cbor/update/SystemTag
+            golden/cbor/update/UpId
+            golden/cbor/update/Vote
+            golden/cbor/utxo/HashTx
+            golden/cbor/utxo/Tx
+            golden/cbor/utxo/TxAttributes
+            golden/cbor/utxo/TxId
+            golden/cbor/utxo/TxInList
+            golden/cbor/utxo/TxIn_Utxo
+            golden/cbor/utxo/TxInWitness_RedeemWitness
+            golden/cbor/utxo/TxInWitness_VKWitness
+            golden/cbor/utxo/TxOut
+            golden/cbor/utxo/TxOut1
+            golden/cbor/utxo/TxOutList
+            golden/cbor/utxo/TxOutList1
+            golden/cbor/utxo/TxPayload1
+            golden/cbor/utxo/TxProof
+            golden/cbor/utxo/TxSig
+            golden/cbor/utxo/TxSigData
+            golden/cbor/utxo/TxWitness
+            golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic

--- a/_sources/cardano-ledger-byron-test/1.4.2/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.4.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/byron/ledger/impl/test'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:38:00Z

--- a/_sources/cardano-ledger-byron-test/1.4.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron-test/1.4.2/revisions/1.cabal
@@ -1,0 +1,236 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-byron-test
+version:             1.4.2
+synopsis:            Test helpers from cardano-ledger exposed to other packages
+description:         Test helpers from cardano-ledger exposed to other packages
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:
+                       Test.Cardano.Chain.Block.CBOR
+                       Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Model
+                       Test.Cardano.Chain.Block.Model.Examples
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Block.ValidationMode
+
+                       Test.Cardano.Chain.Byron.API
+
+                       Test.Cardano.Chain.Buildable
+
+                       Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.CBOR
+                       Test.Cardano.Chain.Common.Compact
+                       Test.Cardano.Chain.Common.Example
+                       Test.Cardano.Chain.Common.Gen
+                       Test.Cardano.Chain.Common.Lovelace
+                       Test.Cardano.Chain.Config
+
+                       Test.Cardano.Chain.Delegation.CBOR
+                       Test.Cardano.Chain.Delegation.Certificate
+                       Test.Cardano.Chain.Delegation.Example
+                       Test.Cardano.Chain.Delegation.Gen
+                       Test.Cardano.Chain.Delegation.Model
+
+                       Test.Cardano.Chain.Elaboration.Block
+                       Test.Cardano.Chain.Elaboration.Delegation
+                       Test.Cardano.Chain.Elaboration.Keys
+                       Test.Cardano.Chain.Elaboration.Update
+                       Test.Cardano.Chain.Elaboration.UTxO
+
+                       Test.Cardano.Chain.Epoch.File
+
+                       Test.Cardano.Chain.Genesis.CBOR
+                       Test.Cardano.Chain.Genesis.Dummy
+                       Test.Cardano.Chain.Genesis.Example
+                       Test.Cardano.Chain.Genesis.Gen
+                       Test.Cardano.Chain.Genesis.Json
+
+                       Test.Cardano.Chain.MempoolPayload.CBOR
+                       Test.Cardano.Chain.MempoolPayload.Example
+                       Test.Cardano.Chain.MempoolPayload.Gen
+
+                       Test.Cardano.Chain.Ssc.CBOR
+
+                       Test.Cardano.Chain.Slotting.CBOR
+                       Test.Cardano.Chain.Slotting.Example
+                       Test.Cardano.Chain.Slotting.Gen
+                       Test.Cardano.Chain.Slotting.Properties
+
+                       Test.Cardano.Chain.UTxO.CBOR
+                       Test.Cardano.Chain.UTxO.Compact
+                       Test.Cardano.Chain.UTxO.Example
+                       Test.Cardano.Chain.UTxO.Gen
+                       Test.Cardano.Chain.UTxO.Model
+                       Test.Cardano.Chain.UTxO.ValidationMode
+
+                       Test.Cardano.Chain.Update.CBOR
+                       Test.Cardano.Chain.Update.Example
+                       Test.Cardano.Chain.Update.Gen
+                       Test.Cardano.Chain.Update.Properties
+
+                       Test.Cardano.Mirror
+
+                       Test.Options
+
+  other-modules:
+                       Paths_cardano_ledger_byron_test
+                       GetDataFileName
+  cpp-options:         -DCARDANO_LEDGER_BYRON_TEST
+  build-depends:       base16-bytestring >= 1
+                     , bimap
+                     , bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-ledger-byron
+                     , cardano-crypto
+                     , cardano-crypto-test
+                     , cardano-crypto-wrapper
+                     , cardano-prelude >= 0.1.0.1
+                     , cardano-prelude-test
+                     , containers
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , directory
+                     , filepath
+                     , formatting
+                     , generic-monoid
+                     , heapwords
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , resourcet
+                     , small-steps
+                     , small-steps-test
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+                     , text
+                     , time
+                     , vector
+
+data-files: golden/cbor/block/BlockSignature
+            golden/cbor/block/Body
+            golden/cbor/block/BoundaryBlockHeader
+            golden/cbor/block/BoundaryBody
+            golden/cbor/block/BoundaryConsensusData
+            golden/cbor/block/BoundaryProof
+            golden/cbor/block/ExtraBodyData
+            golden/cbor/block/Header
+            golden/cbor/block/HeaderHash
+            golden/cbor/block/Proof
+            golden/cbor/block/StaticConfig_GCSpec
+            golden/cbor/block/ToSign
+            golden/cbor/common/Address
+            golden/cbor/common/Address0
+            golden/cbor/common/Address1
+            golden/cbor/common/Address2
+            golden/cbor/common/Address3
+            golden/cbor/common/Address4
+            golden/cbor/common/AddrSpendingData_Redeem
+            golden/cbor/common/AddrSpendingData_VerKey
+            golden/cbor/common/AddrType_R
+            golden/cbor/common/AddrType_VK
+            golden/cbor/common/Attributes
+            golden/cbor/common/BlockCount
+            golden/cbor/common/ChainDifficulty
+            golden/cbor/common/KeyHash
+            golden/cbor/common/Lovelace
+            golden/cbor/common/LovelacePortion
+            golden/cbor/common/MerkleRoot
+            golden/cbor/common/MerkleTree
+            golden/cbor/common/TxFeePolicy_Linear
+            golden/cbor/common/TxSizeLinear
+            golden/cbor/delegation/Certificate
+            golden/cbor/delegation/DlgPayload
+            golden/cbor/mempoolpayload/MempoolPayload
+            golden/cbor/mempoolpayload/MempoolPayload1
+            golden/cbor/mempoolpayload/MempoolPayload2
+            golden/cbor/mempoolpayload/MempoolPayload3
+            golden/cbor/slotting/EpochAndSlotCount
+            golden/cbor/slotting/EpochNumber
+            golden/cbor/slotting/EpochSlots
+            golden/cbor/slotting/SlotNumber
+            golden/cbor/ssc/Commitment
+            golden/cbor/ssc/CommitmentsMap
+            golden/cbor/ssc/InnerSharesMap
+            golden/cbor/ssc/Opening
+            golden/cbor/ssc/OpeningsMap
+            golden/cbor/ssc/SharesMap
+            golden/cbor/ssc/SignedCommitment
+            golden/cbor/ssc/SscPayload_CertificatesPayload
+            golden/cbor/ssc/SscPayload_CommitmentsPayload
+            golden/cbor/ssc/SscPayload_OpeningsPayload
+            golden/cbor/ssc/SscPayload_SharesPayload
+            golden/cbor/ssc/SscProof_CertificatesProof
+            golden/cbor/ssc/SscProof_CommitmentsProof
+            golden/cbor/ssc/SscProof_OpeningsProof
+            golden/cbor/ssc/SscProof_SharesProof
+            golden/cbor/ssc/VssCertificate
+            golden/cbor/ssc/VssCertificatesHash
+            golden/cbor/ssc/VssCertificatesMap
+            golden/cbor/update/ApplicationName
+            golden/cbor/update/AttackTarget_NetworkAddressTarget
+            golden/cbor/update/AttackTarget_PubKeyAddressTarget
+            golden/cbor/update/BlockHeader_Boundary
+            golden/cbor/update/CommitmentSignature
+            golden/cbor/update/HashRaw
+            golden/cbor/update/HashTx
+            golden/cbor/update/InstallerHash
+            golden/cbor/update/Payload
+            golden/cbor/update/Proof
+            golden/cbor/update/Proposal
+            golden/cbor/update/ProposalBody
+            golden/cbor/update/ProtocolParameters
+            golden/cbor/update/ProtocolParametersUpdate
+            golden/cbor/update/ProtocolVersion
+            golden/cbor/update/SharesDistribution
+            golden/cbor/update/SoftforkRule
+            golden/cbor/update/SoftwareVersion
+            golden/cbor/update/StaticConfig_GCSpec
+            golden/cbor/update/StaticConfig_GCSrc
+            golden/cbor/update/SystemTag
+            golden/cbor/update/UpId
+            golden/cbor/update/Vote
+            golden/cbor/utxo/HashTx
+            golden/cbor/utxo/Tx
+            golden/cbor/utxo/TxAttributes
+            golden/cbor/utxo/TxId
+            golden/cbor/utxo/TxInList
+            golden/cbor/utxo/TxIn_Utxo
+            golden/cbor/utxo/TxInWitness_RedeemWitness
+            golden/cbor/utxo/TxInWitness_VKWitness
+            golden/cbor/utxo/TxOut
+            golden/cbor/utxo/TxOut1
+            golden/cbor/utxo/TxOutList
+            golden/cbor/utxo/TxOutList1
+            golden/cbor/utxo/TxPayload1
+            golden/cbor/utxo/TxProof
+            golden/cbor/utxo/TxSig
+            golden/cbor/utxo/TxSigData
+            golden/cbor/utxo/TxWitness
+            golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic

--- a/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:31:41Z

--- a/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/0.1.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/byron/ledger/impl'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:31:41Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:33:41Z

--- a/_sources/cardano-ledger-byron/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,314 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-byron
+version:             0.1.0.0
+synopsis:            The blockchain layer of Cardano during the Byron era
+description:         The blockchain layer of Cardano during the Byron era
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default: False
+    manual: True
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Chain.Block
+                       Cardano.Chain.Byron.API
+                       Cardano.Chain.Common
+                       Cardano.Chain.Constants
+                       Cardano.Chain.Delegation
+                       Cardano.Chain.Delegation.Validation.Activation
+                       Cardano.Chain.Delegation.Validation.Interface
+                       Cardano.Chain.Delegation.Validation.Scheduling
+                       Cardano.Chain.Epoch.File
+                       Cardano.Chain.Epoch.Validation
+                       Cardano.Chain.Genesis
+                       Cardano.Chain.MempoolPayload
+                       Cardano.Chain.ProtocolConstants
+                       Cardano.Chain.Slotting
+                       Cardano.Chain.Ssc
+                       Cardano.Chain.UTxO
+                       Cardano.Chain.UTxO.UTxO
+                       Cardano.Chain.UTxO.Validation
+                       Cardano.Chain.Update
+                       Cardano.Chain.Update.Proposal
+                       Cardano.Chain.Update.Validation.Endorsement
+                       Cardano.Chain.Update.Validation.Interface
+                       Cardano.Chain.Update.Validation.Registration
+                       Cardano.Chain.Update.Validation.Voting
+                       Cardano.Chain.Update.Vote
+                       Cardano.Chain.ValidationMode
+
+  other-modules:
+                       Cardano.Chain.Block.Block
+                       Cardano.Chain.Block.Body
+                       Cardano.Chain.Block.Boundary
+                       Cardano.Chain.Block.Header
+                       Cardano.Chain.Block.Proof
+                       Cardano.Chain.Block.Validation
+                       Cardano.Chain.Block.ValidationMode
+
+                       Cardano.Chain.Byron.API.Common
+                       Cardano.Chain.Byron.API.Mempool
+                       Cardano.Chain.Byron.API.Protocol
+                       Cardano.Chain.Byron.API.Validation
+
+                       Cardano.Chain.Common.AddrAttributes
+                       Cardano.Chain.Common.AddrSpendingData
+                       Cardano.Chain.Common.Address
+                       Cardano.Chain.Common.AddressHash
+                       Cardano.Chain.Common.Attributes
+                       Cardano.Chain.Common.BlockCount
+                       Cardano.Chain.Common.CBOR
+                       Cardano.Chain.Common.ChainDifficulty
+                       Cardano.Chain.Common.Compact
+                       Cardano.Chain.Common.KeyHash
+                       Cardano.Chain.Common.Lovelace
+                       Cardano.Chain.Common.LovelacePortion
+                       Cardano.Chain.Common.Merkle
+                       Cardano.Chain.Common.NetworkMagic
+                       Cardano.Chain.Common.TxFeePolicy
+                       Cardano.Chain.Common.TxSizeLinear
+
+                       Cardano.Chain.Delegation.Certificate
+                       Cardano.Chain.Delegation.Map
+                       Cardano.Chain.Delegation.Payload
+
+                       Cardano.Chain.Genesis.AvvmBalances
+                       Cardano.Chain.Genesis.Config
+                       Cardano.Chain.Genesis.Data
+                       Cardano.Chain.Genesis.Delegation
+                       Cardano.Chain.Genesis.Generate
+                       Cardano.Chain.Genesis.Hash
+                       Cardano.Chain.Genesis.Initializer
+                       Cardano.Chain.Genesis.KeyHashes
+                       Cardano.Chain.Genesis.NonAvvmBalances
+                       Cardano.Chain.Genesis.Spec
+
+                       Cardano.Chain.Slotting.EpochAndSlotCount
+                       Cardano.Chain.Slotting.EpochNumber
+                       Cardano.Chain.Slotting.EpochSlots
+                       Cardano.Chain.Slotting.SlotCount
+                       Cardano.Chain.Slotting.SlotNumber
+
+                       Cardano.Chain.UTxO.Compact
+                       Cardano.Chain.UTxO.GenesisUTxO
+                       Cardano.Chain.UTxO.Tx
+                       Cardano.Chain.UTxO.TxAux
+                       Cardano.Chain.UTxO.TxPayload
+                       Cardano.Chain.UTxO.UTxOConfiguration
+                       Cardano.Chain.UTxO.TxProof
+                       Cardano.Chain.UTxO.TxWitness
+                       Cardano.Chain.UTxO.ValidationMode
+
+                       Cardano.Chain.Update.ApplicationName
+                       Cardano.Chain.Update.InstallerHash
+                       Cardano.Chain.Update.Payload
+                       Cardano.Chain.Update.Proof
+                       Cardano.Chain.Update.ProtocolParameters
+                       Cardano.Chain.Update.ProtocolParametersUpdate
+                       Cardano.Chain.Update.ProtocolVersion
+                       Cardano.Chain.Update.SoftforkRule
+                       Cardano.Chain.Update.SoftwareVersion
+                       Cardano.Chain.Update.SystemTag
+                       Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+  build-depends:       aeson
+                     , base58-bytestring
+                     , bimap >=0.4 && <0.5
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude < 0.1.0.1
+                     , cborg
+                     , containers
+                     , contra-tracer
+                     , cryptonite
+                     , Cabal
+                     , deepseq
+                     , digest
+                     , directory
+                     , filepath
+                     , formatting
+                     , mtl
+                     , nothunks
+                     , quiet
+                     , resourcet
+                     , streaming
+                     , streaming-binary >=0.2 && <0.3
+                     , streaming-bytestring
+                     , text
+                     , time
+                     , vector
+
+test-suite cardano-ledger-byron-test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+
+                       Test.Cardano.Chain.Block.CBOR
+                       Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Model
+                       Test.Cardano.Chain.Block.Model.Examples
+                       Test.Cardano.Chain.Block.Size
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Block.ValidationMode
+                       Test.Cardano.Chain.Byron.API
+
+                       Test.Cardano.Chain.Buildable
+
+                       Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.Attributes
+                       Test.Cardano.Chain.Common.CBOR
+                       Test.Cardano.Chain.Common.Compact
+                       Test.Cardano.Chain.Common.Example
+                       Test.Cardano.Chain.Common.Gen
+                       Test.Cardano.Chain.Common.Lovelace
+                       Test.Cardano.Chain.Config
+
+                       Test.Cardano.Chain.Delegation.CBOR
+                       Test.Cardano.Chain.Delegation.Certificate
+                       Test.Cardano.Chain.Delegation.Example
+                       Test.Cardano.Chain.Delegation.Gen
+                       Test.Cardano.Chain.Delegation.Model
+
+                       Test.Cardano.Chain.Elaboration.Block
+                       Test.Cardano.Chain.Elaboration.Delegation
+                       Test.Cardano.Chain.Elaboration.Keys
+                       Test.Cardano.Chain.Elaboration.Update
+                       Test.Cardano.Chain.Elaboration.UTxO
+
+                       Test.Cardano.Chain.Epoch.File
+
+                       Test.Cardano.Chain.Genesis.CBOR
+                       Test.Cardano.Chain.Genesis.Dummy
+                       Test.Cardano.Chain.Genesis.Example
+                       Test.Cardano.Chain.Genesis.Gen
+                       Test.Cardano.Chain.Genesis.Json
+
+                       Test.Cardano.Chain.MempoolPayload.CBOR
+                       Test.Cardano.Chain.MempoolPayload.Example
+                       Test.Cardano.Chain.MempoolPayload.Gen
+
+                       Test.Cardano.Chain.Ssc.CBOR
+
+                       Test.Cardano.Chain.Slotting.CBOR
+                       Test.Cardano.Chain.Slotting.Example
+                       Test.Cardano.Chain.Slotting.Gen
+                       Test.Cardano.Chain.Slotting.Properties
+
+                       Test.Cardano.Chain.UTxO.CBOR
+                       Test.Cardano.Chain.UTxO.Compact
+                       Test.Cardano.Chain.UTxO.Example
+                       Test.Cardano.Chain.UTxO.Gen
+                       Test.Cardano.Chain.UTxO.Model
+                       Test.Cardano.Chain.UTxO.ValidationMode
+
+                       Test.Cardano.Chain.Update.CBOR
+                       Test.Cardano.Chain.Update.Example
+                       Test.Cardano.Chain.Update.Gen
+                       Test.Cardano.Chain.Update.Properties
+
+                       Test.Cardano.Mirror
+
+                       Test.Options
+
+  build-depends:       base16-bytestring >= 1
+                     , bimap >=0.4 && <0.5
+                     , bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-ledger-byron
+                     , cardano-crypto
+                     , cardano-crypto-test
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cborg
+                     , containers
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , directory
+                     , filepath
+                     , formatting
+                     , generic-monoid
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , resourcet
+                     , small-steps
+                     , small-steps-test
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+                     , text
+                     , time
+                     , vector
+
+  ghc-options:         "-with-rtsopts=-K450K -M500M"
+
+test-suite epoch-validation-normal-form-test
+  import:             base, project-config
+
+  if (!flag(test-normal-form))
+   buildable: False
+
+  hs-source-dirs:      test
+  main-is:             NormalFormTest.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Config
+                       Test.Cardano.Mirror
+                       Test.Options
+
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-ledger
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , directory
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , resourcet
+                     , silently
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+
+  ghc-options:         "-with-rtsopts=-K450K -M500M"

--- a/_sources/cardano-ledger-byron/0.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-byron/0.1.0.0/revisions/2.cabal
@@ -1,0 +1,314 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-byron
+version:             0.1.0.0
+synopsis:            The blockchain layer of Cardano during the Byron era
+description:         The blockchain layer of Cardano during the Byron era
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default: False
+    manual: True
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Chain.Block
+                       Cardano.Chain.Byron.API
+                       Cardano.Chain.Common
+                       Cardano.Chain.Constants
+                       Cardano.Chain.Delegation
+                       Cardano.Chain.Delegation.Validation.Activation
+                       Cardano.Chain.Delegation.Validation.Interface
+                       Cardano.Chain.Delegation.Validation.Scheduling
+                       Cardano.Chain.Epoch.File
+                       Cardano.Chain.Epoch.Validation
+                       Cardano.Chain.Genesis
+                       Cardano.Chain.MempoolPayload
+                       Cardano.Chain.ProtocolConstants
+                       Cardano.Chain.Slotting
+                       Cardano.Chain.Ssc
+                       Cardano.Chain.UTxO
+                       Cardano.Chain.UTxO.UTxO
+                       Cardano.Chain.UTxO.Validation
+                       Cardano.Chain.Update
+                       Cardano.Chain.Update.Proposal
+                       Cardano.Chain.Update.Validation.Endorsement
+                       Cardano.Chain.Update.Validation.Interface
+                       Cardano.Chain.Update.Validation.Registration
+                       Cardano.Chain.Update.Validation.Voting
+                       Cardano.Chain.Update.Vote
+                       Cardano.Chain.ValidationMode
+
+  other-modules:
+                       Cardano.Chain.Block.Block
+                       Cardano.Chain.Block.Body
+                       Cardano.Chain.Block.Boundary
+                       Cardano.Chain.Block.Header
+                       Cardano.Chain.Block.Proof
+                       Cardano.Chain.Block.Validation
+                       Cardano.Chain.Block.ValidationMode
+
+                       Cardano.Chain.Byron.API.Common
+                       Cardano.Chain.Byron.API.Mempool
+                       Cardano.Chain.Byron.API.Protocol
+                       Cardano.Chain.Byron.API.Validation
+
+                       Cardano.Chain.Common.AddrAttributes
+                       Cardano.Chain.Common.AddrSpendingData
+                       Cardano.Chain.Common.Address
+                       Cardano.Chain.Common.AddressHash
+                       Cardano.Chain.Common.Attributes
+                       Cardano.Chain.Common.BlockCount
+                       Cardano.Chain.Common.CBOR
+                       Cardano.Chain.Common.ChainDifficulty
+                       Cardano.Chain.Common.Compact
+                       Cardano.Chain.Common.KeyHash
+                       Cardano.Chain.Common.Lovelace
+                       Cardano.Chain.Common.LovelacePortion
+                       Cardano.Chain.Common.Merkle
+                       Cardano.Chain.Common.NetworkMagic
+                       Cardano.Chain.Common.TxFeePolicy
+                       Cardano.Chain.Common.TxSizeLinear
+
+                       Cardano.Chain.Delegation.Certificate
+                       Cardano.Chain.Delegation.Map
+                       Cardano.Chain.Delegation.Payload
+
+                       Cardano.Chain.Genesis.AvvmBalances
+                       Cardano.Chain.Genesis.Config
+                       Cardano.Chain.Genesis.Data
+                       Cardano.Chain.Genesis.Delegation
+                       Cardano.Chain.Genesis.Generate
+                       Cardano.Chain.Genesis.Hash
+                       Cardano.Chain.Genesis.Initializer
+                       Cardano.Chain.Genesis.KeyHashes
+                       Cardano.Chain.Genesis.NonAvvmBalances
+                       Cardano.Chain.Genesis.Spec
+
+                       Cardano.Chain.Slotting.EpochAndSlotCount
+                       Cardano.Chain.Slotting.EpochNumber
+                       Cardano.Chain.Slotting.EpochSlots
+                       Cardano.Chain.Slotting.SlotCount
+                       Cardano.Chain.Slotting.SlotNumber
+
+                       Cardano.Chain.UTxO.Compact
+                       Cardano.Chain.UTxO.GenesisUTxO
+                       Cardano.Chain.UTxO.Tx
+                       Cardano.Chain.UTxO.TxAux
+                       Cardano.Chain.UTxO.TxPayload
+                       Cardano.Chain.UTxO.UTxOConfiguration
+                       Cardano.Chain.UTxO.TxProof
+                       Cardano.Chain.UTxO.TxWitness
+                       Cardano.Chain.UTxO.ValidationMode
+
+                       Cardano.Chain.Update.ApplicationName
+                       Cardano.Chain.Update.InstallerHash
+                       Cardano.Chain.Update.Payload
+                       Cardano.Chain.Update.Proof
+                       Cardano.Chain.Update.ProtocolParameters
+                       Cardano.Chain.Update.ProtocolParametersUpdate
+                       Cardano.Chain.Update.ProtocolVersion
+                       Cardano.Chain.Update.SoftforkRule
+                       Cardano.Chain.Update.SoftwareVersion
+                       Cardano.Chain.Update.SystemTag
+                       Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+  build-depends:       aeson
+                     , base58-bytestring
+                     , bimap >=0.4 && <0.5
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary <= 1.5.0.0
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude < 0.1.0.1
+                     , cborg
+                     , containers
+                     , contra-tracer
+                     , cryptonite
+                     , Cabal
+                     , deepseq
+                     , digest
+                     , directory
+                     , filepath
+                     , formatting
+                     , mtl
+                     , nothunks
+                     , quiet
+                     , resourcet
+                     , streaming
+                     , streaming-binary >=0.2 && <0.3
+                     , streaming-bytestring
+                     , text
+                     , time
+                     , vector
+
+test-suite cardano-ledger-byron-test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+
+                       Test.Cardano.Chain.Block.CBOR
+                       Test.Cardano.Chain.Block.Gen
+                       Test.Cardano.Chain.Block.Model
+                       Test.Cardano.Chain.Block.Model.Examples
+                       Test.Cardano.Chain.Block.Size
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Block.ValidationMode
+                       Test.Cardano.Chain.Byron.API
+
+                       Test.Cardano.Chain.Buildable
+
+                       Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.Attributes
+                       Test.Cardano.Chain.Common.CBOR
+                       Test.Cardano.Chain.Common.Compact
+                       Test.Cardano.Chain.Common.Example
+                       Test.Cardano.Chain.Common.Gen
+                       Test.Cardano.Chain.Common.Lovelace
+                       Test.Cardano.Chain.Config
+
+                       Test.Cardano.Chain.Delegation.CBOR
+                       Test.Cardano.Chain.Delegation.Certificate
+                       Test.Cardano.Chain.Delegation.Example
+                       Test.Cardano.Chain.Delegation.Gen
+                       Test.Cardano.Chain.Delegation.Model
+
+                       Test.Cardano.Chain.Elaboration.Block
+                       Test.Cardano.Chain.Elaboration.Delegation
+                       Test.Cardano.Chain.Elaboration.Keys
+                       Test.Cardano.Chain.Elaboration.Update
+                       Test.Cardano.Chain.Elaboration.UTxO
+
+                       Test.Cardano.Chain.Epoch.File
+
+                       Test.Cardano.Chain.Genesis.CBOR
+                       Test.Cardano.Chain.Genesis.Dummy
+                       Test.Cardano.Chain.Genesis.Example
+                       Test.Cardano.Chain.Genesis.Gen
+                       Test.Cardano.Chain.Genesis.Json
+
+                       Test.Cardano.Chain.MempoolPayload.CBOR
+                       Test.Cardano.Chain.MempoolPayload.Example
+                       Test.Cardano.Chain.MempoolPayload.Gen
+
+                       Test.Cardano.Chain.Ssc.CBOR
+
+                       Test.Cardano.Chain.Slotting.CBOR
+                       Test.Cardano.Chain.Slotting.Example
+                       Test.Cardano.Chain.Slotting.Gen
+                       Test.Cardano.Chain.Slotting.Properties
+
+                       Test.Cardano.Chain.UTxO.CBOR
+                       Test.Cardano.Chain.UTxO.Compact
+                       Test.Cardano.Chain.UTxO.Example
+                       Test.Cardano.Chain.UTxO.Gen
+                       Test.Cardano.Chain.UTxO.Model
+                       Test.Cardano.Chain.UTxO.ValidationMode
+
+                       Test.Cardano.Chain.Update.CBOR
+                       Test.Cardano.Chain.Update.Example
+                       Test.Cardano.Chain.Update.Gen
+                       Test.Cardano.Chain.Update.Properties
+
+                       Test.Cardano.Mirror
+
+                       Test.Options
+
+  build-depends:       base16-bytestring >= 1
+                     , bimap >=0.4 && <0.5
+                     , bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-ledger-byron
+                     , cardano-crypto
+                     , cardano-crypto-test
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cborg
+                     , containers
+                     , byron-spec-chain
+                     , byron-spec-ledger
+                     , directory
+                     , filepath
+                     , formatting
+                     , generic-monoid
+                     , hedgehog >= 1.0.4
+                     , microlens
+                     , resourcet
+                     , small-steps
+                     , small-steps-test
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+                     , text
+                     , time
+                     , vector
+
+  ghc-options:         "-with-rtsopts=-K450K -M500M"
+
+test-suite epoch-validation-normal-form-test
+  import:             base, project-config
+
+  if (!flag(test-normal-form))
+   buildable: False
+
+  hs-source-dirs:      test
+  main-is:             NormalFormTest.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Chain.Block.Validation
+                       Test.Cardano.Chain.Config
+                       Test.Cardano.Mirror
+                       Test.Options
+
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-ledger
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , directory
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , resourcet
+                     , silently
+                     , streaming
+                     , tasty
+                     , tasty-hedgehog
+
+  ghc-options:         "-with-rtsopts=-K450K -M500M"

--- a/_sources/cardano-ledger-core/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:35:43Z

--- a/_sources/cardano-ledger-core/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,99 @@
+cabal-version:      2.4
+name:               cardano-ledger-core
+version:            0.1.0.0
+synopsis:           Core components of Cardano ledgers from the Shelley release on.
+description:
+  Cardano ledgers from the Shelley release onwards share a core basis rooted in
+  the Shelley ledger specification. This package abstracts a number of components
+  which we expect to be shared amongst all future ledgers implemented around this base.
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+
+license:            Apache-2.0
+author:             IOHK Formal Methods Team
+maintainer:         formal.methods@iohk.io
+copyright:          2021 Input Output (Hong Kong) Ltd.
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/cardano-ledger-core
+
+common base
+  build-depends:
+    base >= 4.12 && < 4.15
+
+common project-config
+  default-language: Haskell2010
+
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+library
+  import:
+    base, project-config
+
+  hs-source-dirs: src
+
+  exposed-modules:
+    Cardano.Ledger.Address
+    Cardano.Ledger.CompactAddress
+    Cardano.Ledger.AuxiliaryData
+    Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BHeaderView
+    Cardano.Ledger.Block
+    Cardano.Ledger.Coin
+    Cardano.Ledger.Compactible
+    Cardano.Ledger.Core
+    Cardano.Ledger.Credential
+    Cardano.Ledger.Crypto
+    Cardano.Ledger.Era
+    Cardano.Ledger.Hashes
+    Cardano.Ledger.Keys
+    Cardano.Ledger.PoolDistr
+    Cardano.Ledger.Rules.ValidationMode
+    Cardano.Ledger.SafeHash
+    Cardano.Ledger.Serialization
+    Cardano.Ledger.Slot
+    Cardano.Ledger.TxIn
+    Cardano.Ledger.UnifiedMap
+    Cardano.Ledger.Val
+
+  build-depends:
+    aeson >= 2,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class < 2.0.0.1,
+    cardano-crypto-praos,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-prelude < 0.1.0.1,
+    cardano-slotting,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    iproute,
+    mtl,
+    network,
+    nothunks,
+    partial-order,
+    quiet,
+    scientific,
+    set-algebra,
+    non-integral,
+    primitive,
+    small-steps,
+    strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:28:59Z

--- a/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/shelley/impl'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:28:59Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:37:40Z

--- a/_sources/cardano-ledger-shelley/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,118 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.0.0
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Constraints
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-ledger-core,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    constraints,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/revisions/2.cabal
@@ -1,0 +1,118 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.0.0
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Constraints
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data <= 0.1.0.0, 
+    cardano-ledger-byron,
+    cardano-ledger-core,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    constraints,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:28:36Z

--- a/_sources/cardano-ledger-shelley/0.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.1.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/shelley/impl'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:28:36Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:37:16Z

--- a/_sources/cardano-ledger-shelley/0.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,125 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.1.1
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PoolParams
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  other-modules:
+    Cardano.Ledger.Shelley.Era
+    Cardano.Ledger.Shelley.LedgerState.Types
+    Cardano.Ledger.Shelley.LedgerState.DPState
+    Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+    Cardano.Ledger.Shelley.LedgerState.NewEpochState
+    Cardano.Ledger.Shelley.LedgerState.PulsingReward
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-ledger-core,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.1.1/revisions/2.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.1.1/revisions/2.cabal
@@ -1,0 +1,125 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.1.1
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PoolParams
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  other-modules:
+    Cardano.Ledger.Shelley.Era
+    Cardano.Ledger.Shelley.LedgerState.Types
+    Cardano.Ledger.Shelley.LedgerState.DPState
+    Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+    Cardano.Ledger.Shelley.LedgerState.NewEpochState
+    Cardano.Ledger.Shelley.LedgerState.PulsingReward
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-ledger-core >= 0.1.1.1,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.1.2/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.1.2/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/shelley/impl'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:28:11Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:36:50Z

--- a/_sources/cardano-ledger-shelley/0.1.1.2/meta.toml
+++ b/_sources/cardano-ledger-shelley/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:28:11Z

--- a/_sources/cardano-ledger-shelley/0.1.1.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,124 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.1.2
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PoolParams
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  other-modules:
+    Cardano.Ledger.Shelley.Era
+    Cardano.Ledger.Shelley.LedgerState.Types
+    Cardano.Ledger.Shelley.LedgerState.DPState
+    Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+    Cardano.Ledger.Shelley.LedgerState.NewEpochState
+    Cardano.Ledger.Shelley.LedgerState.PulsingReward
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-ledger-core,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-shelley/0.1.1.2/revisions/2.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.1.2/revisions/2.cabal
@@ -1,0 +1,124 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.1.2
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PoolParams
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  other-modules:
+    Cardano.Ledger.Shelley.Era
+    Cardano.Ledger.Shelley.LedgerState.Types
+    Cardano.Ledger.Shelley.LedgerState.DPState
+    Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+    Cardano.Ledger.Shelley.LedgerState.NewEpochState
+    Cardano.Ledger.Shelley.LedgerState.PulsingReward
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-ledger-core >= 0.1.1.1,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-node/1.35.4/meta.toml
+++ b/_sources/cardano-node/1.35.4/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-10T17:31:44Z
 github = { repo = "input-output-hk/cardano-node", rev = "ebc7be471b30e5931b35f9bbc236d21c375b91bb" }
 subdir = 'cardano-node'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:39:16Z

--- a/_sources/cardano-node/1.35.4/revisions/1.cabal
+++ b/_sources/cardano-node/1.35.4/revisions/1.cabal
@@ -1,0 +1,236 @@
+cabal-version: 3.0
+
+name:                   cardano-node
+version:                1.35.4
+description:            The cardano full node
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     ChangeLog.md
+
+Flag unexpected_thunks
+  Description:    Turn on unexpected thunks checks
+  Default:        False
+
+flag systemd
+  description:    Enable systemd support
+  default:        True
+  manual:         False
+
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  default-extensions:   NoImplicitPrelude
+                        OverloadedStrings
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+common maybe-Win32
+  if os(windows)
+    build-depends:      Win32
+
+common maybe-unix
+  if !os(windows)
+    build-depends:      unix
+
+library
+  import:               base, project-config
+                      , maybe-unix
+                      , maybe-Win32
+  if flag(unexpected_thunks)
+    cpp-options: -DUNEXPECTED_THUNKS
+
+  if os(linux) && flag(systemd)
+    cpp-options: -DSYSTEMD
+    build-depends:     lobemo-scribe-systemd
+                     , systemd
+
+  hs-source-dirs:      src
+
+  exposed-modules:     Cardano.Node.Configuration.Logging
+                       Cardano.Node.Configuration.NodeAddress
+                       Cardano.Node.Configuration.POM
+                       Cardano.Node.Configuration.Socket
+                       Cardano.Node.Configuration.Topology
+                       Cardano.Node.Configuration.TopologyP2P
+                       Cardano.Node.Handlers.Shutdown
+                       Cardano.Node.Handlers.TopLevel
+                       Cardano.Node.Orphans
+                       Cardano.Node.Protocol
+                       Cardano.Node.Protocol.Alonzo
+                       Cardano.Node.Protocol.Byron
+                       Cardano.Node.Protocol.Cardano
+                       Cardano.Node.Protocol.Shelley
+                       Cardano.Node.Protocol.Types
+                       Cardano.Node.Parsers
+                       Cardano.Node.Queries
+                       Cardano.Node.Run
+                       Cardano.Node.STM
+                       Cardano.Node.Startup
+                       Cardano.Node.TraceConstraints
+                       Cardano.Node.Tracing
+                       Cardano.Node.Types
+                       Cardano.Node.Tracing.API
+                       Cardano.Node.Tracing.Compat
+                       Cardano.Node.Tracing.Documentation
+                       Cardano.Node.Tracing.Era.Byron
+                       Cardano.Node.Tracing.Era.HardFork
+                       Cardano.Node.Tracing.Era.Shelley
+                       Cardano.Node.Tracing.Peers
+                       Cardano.Node.Tracing.StateRep
+                       Cardano.Node.Tracing.Tracers
+                       Cardano.Node.Tracing.Tracers.BlockReplayProgress
+                       Cardano.Node.Tracing.Tracers.ChainDB
+                       Cardano.Node.Tracing.Tracers.Consensus
+                       Cardano.Node.Tracing.Tracers.Diffusion
+                       Cardano.Node.Tracing.Tracers.KESInfo
+                       Cardano.Node.Tracing.Tracers.StartLeadershipCheck
+                       Cardano.Node.Tracing.Tracers.ForgingThreadStats
+                       Cardano.Node.Tracing.Tracers.Resources
+                       Cardano.Node.Tracing.Tracers.Peer
+                       Cardano.Node.Tracing.Tracers.Startup
+                       Cardano.Node.Tracing.Tracers.Shutdown
+                       Cardano.Node.Tracing.Tracers.P2P
+                       Cardano.Node.Tracing.Tracers.NonP2P
+                       Cardano.Node.Tracing.Tracers.NodeToClient
+                       Cardano.Node.Tracing.Tracers.NodeToNode
+                       Cardano.Node.Tracing.Formatting
+                       Cardano.Node.Tracing.Render
+                       Cardano.Tracing.Config
+                       Cardano.Tracing.Metrics
+                       Cardano.Tracing.Peer
+                       Cardano.Tracing.Render
+                       Cardano.Tracing.Startup
+                       Cardano.Tracing.Shutdown
+                       Cardano.Tracing.Tracers
+                       Cardano.Tracing.OrphanInstances.Byron
+                       Cardano.Tracing.OrphanInstances.Common
+                       Cardano.Tracing.OrphanInstances.Consensus
+                       Cardano.Tracing.OrphanInstances.HardFork
+                       Cardano.Tracing.OrphanInstances.Network
+                       Cardano.Tracing.OrphanInstances.Shelley
+
+  other-modules:       Paths_cardano_node
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , async
+                      , base16-bytestring
+                      , bytestring
+                      , deepseq
+                      , cardano-api == 1.35.4
+                      , cardano-data
+                      , cardano-git-rev
+                      , cardano-crypto-class
+                      , cardano-crypto-wrapper
+                      , cardano-ledger-alonzo < 0.1.1
+                      , cardano-ledger-babbage < 0.1.1
+                      , cardano-ledger-byron < 0.1.1
+                      , cardano-ledger-core < 0.1.1
+                      , cardano-ledger-shelley-ma < 0.1.1
+                      , cardano-prelude
+                      , cardano-protocol-tpraos
+                      , cardano-slotting
+                      , cborg >= 0.2.4 && < 0.3
+                      , contra-tracer
+                      , containers
+                      , directory
+                      , dns
+                      , ekg
+                      , ekg-core
+                      , filepath
+                      , generic-data
+                      , hostname
+                      , iproute
+                      , io-classes
+                      , iohk-monitoring
+                      , lobemo-backend-aggregation
+                      , lobemo-backend-ekg
+                      , lobemo-backend-monitoring
+                      , lobemo-backend-trace-forwarder
+                      , network
+                      , network-mux
+                      , nothunks
+                      , optparse-applicative-fork
+                      , ouroboros-consensus < 0.1.0.1
+                      , ouroboros-consensus-byron < 0.1.0.1
+                      , ouroboros-consensus-cardano < 0.1.0.1
+                      , ouroboros-consensus-protocol < 0.1.0.1
+                      , ouroboros-consensus-shelley < 0.1.0.1
+                      , ouroboros-network < 0.1.0.1
+                      , ouroboros-network-framework < 0.1.0.1
+                      , psqueues
+                      , safe-exceptions
+                      , scientific
+                      , strict-stm
+                      , cardano-ledger-shelley < 0.1.1
+                      , small-steps
+                      , stm
+                      , text
+                      , time
+                      , tracer-transformers
+                      , trace-dispatcher
+                      , trace-forward
+                      , trace-resources
+                      , transformers
+                      , transformers-except
+                      , typed-protocols
+                      , yaml
+
+executable cardano-node
+  import:               base, project-config
+  hs-source-dirs:       app
+  main-is:              cardano-node.hs
+  ghc-options:          -threaded
+                        -rtsopts
+
+  if arch(arm)
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
+  else
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
+
+  other-modules:        Paths_cardano_node
+
+  build-depends:        cardano-git-rev
+                      , cardano-node
+                      , cardano-prelude
+                      , optparse-applicative-fork
+                      , text
+
+test-suite cardano-node-test
+  import:               base, project-config
+                      , maybe-unix
+  hs-source-dirs:       test
+  main-is:              cardano-node-test.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , cardano-api
+                      , cardano-node
+                      , cardano-prelude
+                      , cardano-slotting
+                      , directory
+                      , hedgehog
+                      , hedgehog-corpus
+                      , iproute
+                      , ouroboros-consensus
+                      , ouroboros-network
+                      , time
+
+  other-modules:        Test.Cardano.Node.FilePermissions
+                        Test.Cardano.Node.Gen
+                        Test.Cardano.Node.Json
+                        Test.Cardano.Node.POM
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/_sources/cardano-prelude/0.1.0.0/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-prelude", rev = "bb4ed71ba8e587f672d06edf9d2e376f4b055555" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:32:04Z

--- a/_sources/cardano-prelude/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,72 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.1.0.0
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+license:              MIT
+license-file:         LICENSE
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2021 IOHK
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.HeapWords
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Strict
+
+  build-depends:      base               >= 4.14       && < 4.15
+                    , aeson
+                    , array
+                    , base16-bytestring  >= 1
+                    , bytestring
+                    , canonical-json
+                    , cborg
+                    , containers
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , mtl
+                    , protolude < 0.3.1
+                    , tagged
+                    , text
+                    , time
+                    , vector
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Weverything
+                      -fno-warn-all-missed-specialisations
+                      -fno-warn-missing-deriving-strategies
+                      -fno-warn-missing-import-lists
+                      -fno-warn-missing-safe-haskell-mode
+                      -fno-warn-prepositive-qualified-module
+                      -fno-warn-safe
+                      -fno-warn-unsafe
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-byron'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:27:41Z

--- a/_sources/ouroboros-consensus-byron/0.1.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-byron/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,109 @@
+name:                  ouroboros-consensus-byron
+version:               0.1.0.0
+synopsis:              Byron ledger integration in the Ouroboros consensus layer
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Byron.Crypto.DSIGN
+                       Ouroboros.Consensus.Byron.EBBs
+                       Ouroboros.Consensus.Byron.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Block
+                       Ouroboros.Consensus.Byron.Ledger.Config
+                       Ouroboros.Consensus.Byron.Ledger.Conversions
+                       Ouroboros.Consensus.Byron.Ledger.Forge
+                       Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+                       Ouroboros.Consensus.Byron.Ledger.Inspect
+                       Ouroboros.Consensus.Byron.Ledger.Integrity
+                       Ouroboros.Consensus.Byron.Ledger.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Mempool
+                       Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Byron.Ledger.Orphans
+                       Ouroboros.Consensus.Byron.Ledger.PBFT
+                       Ouroboros.Consensus.Byron.Ledger.Serialisation
+                       Ouroboros.Consensus.Byron.Node
+                       Ouroboros.Consensus.Byron.Node.Serialisation
+                       Ouroboros.Consensus.Byron.Protocol
+
+  build-depends:       base              >=4.9   && <4.15
+                     , bytestring        >=0.10  && <0.11
+                     , cardano-binary    < 1.6
+                     , cardano-crypto
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-byron
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , cryptonite        >=0.25  && <0.28
+                     , formatting        >=6.3   && <6.4
+                     , mtl               >=2.2   && <2.3
+                     , serialise         >=0.2   && <0.3
+                     , nothunks
+                     , text              >=1.2   && <1.3
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-converter
+  hs-source-dirs:      tools/db-converter
+  main-is:             Main.hs
+  build-depends:       base
+                     , bytestring
+                     , cardano-binary
+                     , cardano-ledger-byron
+                     , directory
+                     , filepath
+                     , mtl
+                     , optparse-generic
+                     , resourcet
+                     , streaming
+                     , text
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/_sources/ouroboros-consensus-byron/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-25T17:33:07Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
 subdir = 'ouroboros-consensus-byron'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:26:43Z

--- a/_sources/ouroboros-consensus-byron/0.1.0.1/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-byron/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,109 @@
+name:                  ouroboros-consensus-byron
+version:               0.1.0.1
+synopsis:              Byron ledger integration in the Ouroboros consensus layer
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Byron.Crypto.DSIGN
+                       Ouroboros.Consensus.Byron.EBBs
+                       Ouroboros.Consensus.Byron.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Block
+                       Ouroboros.Consensus.Byron.Ledger.Config
+                       Ouroboros.Consensus.Byron.Ledger.Conversions
+                       Ouroboros.Consensus.Byron.Ledger.Forge
+                       Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+                       Ouroboros.Consensus.Byron.Ledger.Inspect
+                       Ouroboros.Consensus.Byron.Ledger.Integrity
+                       Ouroboros.Consensus.Byron.Ledger.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Mempool
+                       Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Byron.Ledger.Orphans
+                       Ouroboros.Consensus.Byron.Ledger.PBFT
+                       Ouroboros.Consensus.Byron.Ledger.Serialisation
+                       Ouroboros.Consensus.Byron.Node
+                       Ouroboros.Consensus.Byron.Node.Serialisation
+                       Ouroboros.Consensus.Byron.Protocol
+
+  build-depends:       base              >=4.9   && <4.15
+                     , bytestring        >=0.10  && <0.11
+                     , cardano-binary    < 1.6
+                     , cardano-crypto
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-byron
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , cryptonite        >=0.25  && <0.28
+                     , formatting        >=6.3   && <6.4
+                     , mtl               >=2.2   && <2.3
+                     , serialise         >=0.2   && <0.3
+                     , nothunks
+                     , text              >=1.2   && <1.3
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-converter
+  hs-source-dirs:      tools/db-converter
+  main-is:             Main.hs
+  build-depends:       base
+                     , bytestring
+                     , cardano-binary
+                     , cardano-ledger-byron
+                     , directory
+                     , filepath
+                     , mtl
+                     , optparse-generic
+                     , resourcet
+                     , streaming
+                     , text
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/_sources/ouroboros-consensus-byron/0.2.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-11T17:00:00Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "4ad75c4c463f591c28493aa61220196f941aab4c" }
 subdir = 'ouroboros-consensus-byron'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:25:11Z

--- a/_sources/ouroboros-consensus-byron/0.2.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-byron/0.2.0.0/revisions/1.cabal
@@ -1,0 +1,112 @@
+cabal-version: 3.0
+
+name:                   ouroboros-consensus-byron
+version:                0.2.0.0
+synopsis:               Byron ledger integration in the Ouroboros consensus layer
+description:            Byron ledger integration in the Ouroboros consensus layer.
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019-2023 Input Output Global Inc (IOG)
+author:                 IOHK Engineering Team
+maintainer:             operations@iohk.io
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Byron.Crypto.DSIGN
+                       Ouroboros.Consensus.Byron.EBBs
+                       Ouroboros.Consensus.Byron.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Block
+                       Ouroboros.Consensus.Byron.Ledger.Config
+                       Ouroboros.Consensus.Byron.Ledger.Conversions
+                       Ouroboros.Consensus.Byron.Ledger.Forge
+                       Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+                       Ouroboros.Consensus.Byron.Ledger.Inspect
+                       Ouroboros.Consensus.Byron.Ledger.Integrity
+                       Ouroboros.Consensus.Byron.Ledger.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Mempool
+                       Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Byron.Ledger.Orphans
+                       Ouroboros.Consensus.Byron.Ledger.PBFT
+                       Ouroboros.Consensus.Byron.Ledger.Serialisation
+                       Ouroboros.Consensus.Byron.Node
+                       Ouroboros.Consensus.Byron.Node.Serialisation
+                       Ouroboros.Consensus.Byron.Protocol
+
+  build-depends:       base              >=4.14  && <4.17
+                     , bytestring        >=0.10  && <0.12
+                     , cardano-binary    < 1.6
+                     , cardano-crypto
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-byron
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , cryptonite        >=0.25  && <0.31
+                     , formatting        >=6.3   && <7.2
+                     , mtl               >=2.2   && <2.3
+                     , serialise         >=0.2   && <0.3
+                     , nothunks
+                     , text              >=1.2   && <1.3
+
+                     , ouroboros-network-api
+                     , ouroboros-network-protocols
+                     , ouroboros-consensus
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-converter
+  hs-source-dirs:      tools/db-converter
+  main-is:             Main.hs
+  build-depends:       base              >=4.14 && <4.17
+                     , bytestring
+                     , cardano-binary
+                     , cardano-ledger-byron
+                     , directory
+                     , filepath
+                     , mtl
+                     , optparse-generic
+                     , resourcet
+                     , streaming
+                     , text
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-diffusion
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/_sources/ouroboros-consensus-byron/0.3.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-byron/0.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-13T11:33:44Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "a251fc8f8f452be2804c89ea8ea6f425ccab5dd6" }
 subdir = 'ouroboros-consensus-byron'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:23:59Z

--- a/_sources/ouroboros-consensus-byron/0.3.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-byron/0.3.0.0/revisions/1.cabal
@@ -1,0 +1,112 @@
+cabal-version: 3.0
+
+name:                   ouroboros-consensus-byron
+version:                0.3.0.0
+synopsis:               Byron ledger integration in the Ouroboros consensus layer
+description:            Byron ledger integration in the Ouroboros consensus layer.
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019-2023 Input Output Global Inc (IOG)
+author:                 IOHK Engineering Team
+maintainer:             operations@iohk.io
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Byron.Crypto.DSIGN
+                       Ouroboros.Consensus.Byron.EBBs
+                       Ouroboros.Consensus.Byron.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Block
+                       Ouroboros.Consensus.Byron.Ledger.Config
+                       Ouroboros.Consensus.Byron.Ledger.Conversions
+                       Ouroboros.Consensus.Byron.Ledger.Forge
+                       Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+                       Ouroboros.Consensus.Byron.Ledger.Inspect
+                       Ouroboros.Consensus.Byron.Ledger.Integrity
+                       Ouroboros.Consensus.Byron.Ledger.Ledger
+                       Ouroboros.Consensus.Byron.Ledger.Mempool
+                       Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Byron.Ledger.Orphans
+                       Ouroboros.Consensus.Byron.Ledger.PBFT
+                       Ouroboros.Consensus.Byron.Ledger.Serialisation
+                       Ouroboros.Consensus.Byron.Node
+                       Ouroboros.Consensus.Byron.Node.Serialisation
+                       Ouroboros.Consensus.Byron.Protocol
+
+  build-depends:       base              >=4.14  && <4.17
+                     , bytestring        >=0.10  && <0.12
+                     , cardano-binary    < 1.6
+                     , cardano-crypto
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-byron
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , cryptonite        >=0.25  && <0.31
+                     , formatting        >=6.3   && <7.2
+                     , mtl               >=2.2   && <2.3
+                     , serialise         >=0.2   && <0.3
+                     , nothunks
+                     , text              >=1.2   && <1.3
+
+                     , ouroboros-network-api
+                     , ouroboros-network-protocols
+                     , ouroboros-consensus
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-converter
+  hs-source-dirs:      tools/db-converter
+  main-is:             Main.hs
+  build-depends:       base              >=4.14 && <4.17
+                     , bytestring
+                     , cardano-binary
+                     , cardano-ledger-byron
+                     , directory
+                     , filepath
+                     , mtl
+                     , optparse-generic
+                     , resourcet
+                     , streaming
+                     , text
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-diffusion
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "cb9eba406ceb2df338d8384b35c8addfe2067201" }
 subdir = 'ouroboros-consensus-cardano'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:38:51Z

--- a/_sources/ouroboros-consensus-cardano/0.1.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,121 @@
+name:                  ouroboros-consensus-cardano
+version:               0.1.0.0
+synopsis:              The instantation of the Ouroboros consensus layer used by Cardano
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+                       Ouroboros.Consensus.Cardano
+                       Ouroboros.Consensus.Cardano.Block
+                       Ouroboros.Consensus.Cardano.ByronHFC
+                       Ouroboros.Consensus.Cardano.Condense
+                       Ouroboros.Consensus.Cardano.CanHardFork
+                       Ouroboros.Consensus.Cardano.Node
+                       Ouroboros.Consensus.Cardano.ShelleyBased
+
+  build-depends:       base              >=4.9   && <4.15
+                     , bytestring        >=0.10  && <0.11
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , these             >=1.1   && <1.2
+
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-byron
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , cardano-prelude
+                     , cardano-protocol-tpraos < 0.1.1.1
+                     , cardano-slotting
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-protocol
+                     , ouroboros-consensus-shelley
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-analyser
+  hs-source-dirs:      tools/db-analyser
+  main-is:             Main.hs
+  build-depends:       aeson
+                     , base
+                     , bytestring
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-byron
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cborg
+                     , containers
+                     , contra-tracer
+                     , mtl
+                     , nothunks
+                     , optparse-applicative
+                     , serialise
+                     , strict-containers
+                     , text
+
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-cardano
+                     , ouroboros-consensus-protocol
+                     , ouroboros-consensus-shelley
+                     , ouroboros-network
+                     , plutus-ledger-api
+  other-modules:
+                       Analysis
+                     , Block.Byron
+                     , Block.Cardano
+                     , Block.Shelley
+                     , HasAnalysis
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -threaded
+                       -rtsopts
+                       "-with-rtsopts=-T -I0 -N2 -A16m"

--- a/_sources/ouroboros-consensus-cardano/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-25T17:33:07Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
 subdir = 'ouroboros-consensus-cardano'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:40:43Z

--- a/_sources/ouroboros-consensus-cardano/0.1.0.1/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,121 @@
+name:                  ouroboros-consensus-cardano
+version:               0.1.0.1
+synopsis:              The instantation of the Ouroboros consensus layer used by Cardano
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+                       Ouroboros.Consensus.Cardano
+                       Ouroboros.Consensus.Cardano.Block
+                       Ouroboros.Consensus.Cardano.ByronHFC
+                       Ouroboros.Consensus.Cardano.Condense
+                       Ouroboros.Consensus.Cardano.CanHardFork
+                       Ouroboros.Consensus.Cardano.Node
+                       Ouroboros.Consensus.Cardano.ShelleyBased
+
+  build-depends:       base              >=4.9   && <4.15
+                     , bytestring        >=0.10  && <0.11
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , these             >=1.1   && <1.2
+
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-byron
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , cardano-prelude
+                     , cardano-protocol-tpraos
+                     , cardano-slotting
+
+                     , ouroboros-network <= 0.1.0.1
+                     , ouroboros-consensus <= 0.1.0.1
+                     , ouroboros-consensus-byron <= 0.1.0.1
+                     , ouroboros-consensus-protocol <= 0.1.0.1
+                     , ouroboros-consensus-shelley <= 0.1.0.1
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+executable db-analyser
+  hs-source-dirs:      tools/db-analyser
+  main-is:             Main.hs
+  build-depends:       aeson
+                     , base
+                     , bytestring
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-byron
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cborg
+                     , containers
+                     , contra-tracer
+                     , mtl
+                     , nothunks
+                     , optparse-applicative
+                     , serialise
+                     , strict-containers
+                     , text
+
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-cardano
+                     , ouroboros-consensus-protocol
+                     , ouroboros-consensus-shelley
+                     , ouroboros-network
+                     , plutus-ledger-api
+  other-modules:
+                       Analysis
+                     , Block.Byron
+                     , Block.Cardano
+                     , Block.Shelley
+                     , HasAnalysis
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -threaded
+                       -rtsopts
+                       "-with-rtsopts=-T -I0 -N2 -A16m"

--- a/_sources/ouroboros-consensus-cardano/0.3.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-13T11:33:09Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "a251fc8f8f452be2804c89ea8ea6f425ccab5dd6" }
 subdir = 'ouroboros-consensus-cardano'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:24:44Z

--- a/_sources/ouroboros-consensus-cardano/0.3.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.3.0.0/revisions/1.cabal
@@ -1,0 +1,75 @@
+cabal-version:         3.0
+
+name:                   ouroboros-consensus-cardano
+version:                0.3.0.0
+synopsis:               The instantation of the Ouroboros consensus layer used by Cardano
+description:            The instantation of the Ouroboros consensus layer used by Cardano.
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019-2023 Input Output Global Inc (IOG)
+author:                 IOHK Engineering Team
+maintainer:             operations@iohk.io
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+                       Ouroboros.Consensus.Cardano
+                       Ouroboros.Consensus.Cardano.Block
+                       Ouroboros.Consensus.Cardano.ByronHFC
+                       Ouroboros.Consensus.Cardano.Condense
+                       Ouroboros.Consensus.Cardano.CanHardFork
+                       Ouroboros.Consensus.Cardano.Node
+                       Ouroboros.Consensus.Cardano.ShelleyBased
+
+  build-depends:       base              >=4.14  && <4.17
+                     , bytestring        >=0.10  && <0.12
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , these             >=1.1   && <1.2
+
+                     , cardano-binary    < 1.6
+                     , cardano-crypto-class
+                     , cardano-data
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-byron
+                     , cardano-ledger-conway
+                     , cardano-ledger-core
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , cardano-prelude
+                     , cardano-protocol-tpraos
+                     , cardano-slotting
+
+                     , ouroboros-network ^>= 0.4
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-protocol
+                     , ouroboros-consensus-shelley
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-25T17:33:07Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "b6ab4ca226ba541ee89374a30824351a91285226" }
 subdir = 'ouroboros-consensus-shelley'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:39:40Z

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'ouroboros-consensus-shelley'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:39:40Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:40:00Z

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,100 @@
+name:                  ouroboros-consensus-shelley
+version:               0.1.0.1
+synopsis:              Shelley ledger integration in the Ouroboros consensus layer
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Shelley.Crypto
+                       Ouroboros.Consensus.Shelley.Eras
+                       Ouroboros.Consensus.Shelley.HFEras
+                       Ouroboros.Consensus.Shelley.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Block
+                       Ouroboros.Consensus.Shelley.Ledger.Config
+                       Ouroboros.Consensus.Shelley.Ledger.Forge
+                       Ouroboros.Consensus.Shelley.Ledger.Inspect
+                       Ouroboros.Consensus.Shelley.Ledger.Integrity
+                       Ouroboros.Consensus.Shelley.Ledger.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Mempool
+                       Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Shelley.Ledger.Query
+                       Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+                       Ouroboros.Consensus.Shelley.Ledger.Protocol
+                       Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Shelley.Node
+                       Ouroboros.Consensus.Shelley.Node.Common
+                       Ouroboros.Consensus.Shelley.Node.Praos
+                       Ouroboros.Consensus.Shelley.Node.TPraos
+                       Ouroboros.Consensus.Shelley.Node.Serialisation
+                       Ouroboros.Consensus.Shelley.Protocol.Abstract
+                       Ouroboros.Consensus.Shelley.Protocol.Praos
+                       Ouroboros.Consensus.Shelley.Protocol.TPraos
+                       Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  build-depends:       base              >=4.9   && <4.15
+                     , base-deriving-via
+                     , bytestring        >=0.10  && <0.11
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-praos
+                     , cardano-data
+                     , cardano-ledger-core
+                     , cardano-protocol-tpraos < 0.1.1
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , data-default-class
+                     , deepseq
+                     , measures
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , orphans-deriving-via
+                     , serialise         >=0.2   && <0.3
+                     , strict-containers
+                     , text              >=1.2   && <1.3
+                     , transformers
+
+                       -- cardano-ledger-specs
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , small-steps
+
+                     , ouroboros-network
+                     , ouroboros-consensus
+                     , ouroboros-consensus-protocol
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/2.cabal
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/2.cabal
@@ -1,0 +1,100 @@
+name:                  ouroboros-consensus-shelley
+version:               0.1.0.1
+synopsis:              Shelley ledger integration in the Ouroboros consensus layer
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Shelley.Crypto
+                       Ouroboros.Consensus.Shelley.Eras
+                       Ouroboros.Consensus.Shelley.HFEras
+                       Ouroboros.Consensus.Shelley.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Block
+                       Ouroboros.Consensus.Shelley.Ledger.Config
+                       Ouroboros.Consensus.Shelley.Ledger.Forge
+                       Ouroboros.Consensus.Shelley.Ledger.Inspect
+                       Ouroboros.Consensus.Shelley.Ledger.Integrity
+                       Ouroboros.Consensus.Shelley.Ledger.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Mempool
+                       Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Shelley.Ledger.Query
+                       Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+                       Ouroboros.Consensus.Shelley.Ledger.Protocol
+                       Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Shelley.Node
+                       Ouroboros.Consensus.Shelley.Node.Common
+                       Ouroboros.Consensus.Shelley.Node.Praos
+                       Ouroboros.Consensus.Shelley.Node.TPraos
+                       Ouroboros.Consensus.Shelley.Node.Serialisation
+                       Ouroboros.Consensus.Shelley.Protocol.Abstract
+                       Ouroboros.Consensus.Shelley.Protocol.Praos
+                       Ouroboros.Consensus.Shelley.Protocol.TPraos
+                       Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  build-depends:       base              >=4.9   && <4.15
+                     , base-deriving-via
+                     , bytestring        >=0.10  && <0.11
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-praos
+                     , cardano-data
+                     , cardano-ledger-core
+                     , cardano-protocol-tpraos < 0.1.1
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , data-default-class
+                     , deepseq
+                     , measures
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , orphans-deriving-via
+                     , serialise         >=0.2   && <0.3
+                     , strict-containers
+                     , text              >=1.2   && <1.3
+                     , transformers
+
+                       -- cardano-ledger-specs
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , small-steps
+
+                     , ouroboros-network < 0.2
+                     , ouroboros-consensus < 0.2
+                     , ouroboros-consensus-protocol < 0.2
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts

--- a/_sources/plutus-core/1.0.0.1/meta.toml
+++ b/_sources/plutus-core/1.0.0.1/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/plutus", rev = "d5f6f4a5505094490f61c8d164515adf7c8f46cc" }
 subdir = 'plutus-core'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:30:01Z

--- a/_sources/plutus-core/1.0.0.1/revisions/1.cabal
+++ b/_sources/plutus-core/1.0.0.1/revisions/1.cabal
@@ -1,0 +1,868 @@
+cabal-version:      3.0
+name:               plutus-core
+version:            1.0.0.1
+license:            Apache-2.0
+license-file:       LICENSE NOTICE
+maintainer:         michael.peyton-jones@iohk.io
+author:             Plutus Core Team
+synopsis:           Language library for Plutus Core
+description:        Pretty-printer, parser, and typechecker for Plutus Core.
+category:           Language, Plutus
+build-type:         Simple
+extra-source-files:
+    cost-model/data/*.R
+    cost-model/data/benching.csv
+    cost-model/data/builtinCostModel.json
+    cost-model/data/cekMachineCosts.json
+    plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+extra-doc-files:    README.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/plutus
+
+library
+    exposed-modules:
+        Crypto
+        Data.ByteString.Hash
+        Data.SatInt
+        ErrorCode
+        PlutusCore
+        PlutusCore.Builtin
+        PlutusCore.Builtin.Debug
+        PlutusCore.Builtin.Elaborate
+        PlutusCore.Builtin.Emitter
+        PlutusCore.Check.Normal
+        PlutusCore.Check.Scoping
+        PlutusCore.Check.Uniques
+        PlutusCore.Check.Value
+        PlutusCore.Core
+        PlutusCore.Data
+        PlutusCore.DataFilePaths
+        PlutusCore.DeBruijn
+        PlutusCore.Default
+        PlutusCore.Error
+        PlutusCore.Evaluation.Machine.BuiltinCostModel
+        PlutusCore.Evaluation.Machine.Ck
+        PlutusCore.Evaluation.Machine.CostModelInterface
+        PlutusCore.Evaluation.Machine.ExBudget
+        PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+        PlutusCore.Evaluation.Machine.Exception
+        PlutusCore.Evaluation.Machine.ExMemory
+        PlutusCore.Evaluation.Machine.MachineParameters
+        PlutusCore.Evaluation.Result
+        PlutusCore.Examples.Builtins
+        PlutusCore.Examples.Data.Data
+        PlutusCore.Examples.Data.InterList
+        PlutusCore.Examples.Data.List
+        PlutusCore.Examples.Data.Pair
+        PlutusCore.Examples.Data.Shad
+        PlutusCore.Examples.Data.TreeForest
+        PlutusCore.Examples.Data.Vec
+        PlutusCore.Examples.Everything
+        PlutusCore.Flat
+        PlutusCore.FsTree
+        PlutusCore.Mark
+        PlutusCore.MkPlc
+        PlutusCore.Name
+        PlutusCore.Normalize
+        PlutusCore.Normalize.Internal
+        PlutusCore.Parser
+        PlutusCore.Pretty
+        PlutusCore.Quote
+        PlutusCore.Rename
+        PlutusCore.Rename.Internal
+        PlutusCore.Rename.Monad
+        PlutusCore.StdLib.Data.Bool
+        PlutusCore.StdLib.Data.ChurchNat
+        PlutusCore.StdLib.Data.Data
+        PlutusCore.StdLib.Data.Function
+        PlutusCore.StdLib.Data.Integer
+        PlutusCore.StdLib.Data.List
+        PlutusCore.StdLib.Data.Nat
+        PlutusCore.StdLib.Data.Pair
+        PlutusCore.StdLib.Data.ScottList
+        PlutusCore.StdLib.Data.ScottUnit
+        PlutusCore.StdLib.Data.Sum
+        PlutusCore.StdLib.Data.Unit
+        PlutusCore.StdLib.Everything
+        PlutusCore.StdLib.Meta
+        PlutusCore.StdLib.Meta.Data.Function
+        PlutusCore.StdLib.Meta.Data.Tuple
+        PlutusCore.StdLib.Type
+        PlutusCore.Subst
+        PlutusIR
+        PlutusIR.Analysis.RetainedSize
+        PlutusIR.Compiler
+        PlutusIR.Compiler.Definitions
+        PlutusIR.Compiler.Names
+        PlutusIR.Core
+        PlutusIR.Core.Instance
+        PlutusIR.Core.Instance.Flat
+        PlutusIR.Core.Instance.Pretty
+        PlutusIR.Core.Instance.Scoping
+        PlutusIR.Core.Plated
+        PlutusIR.Core.Type
+        PlutusIR.Error
+        PlutusIR.Mark
+        PlutusIR.MkPir
+        PlutusIR.Parser
+        PlutusIR.Purity
+        PlutusIR.Subst
+        PlutusIR.Transform.Beta
+        PlutusIR.Transform.DeadCode
+        PlutusIR.Transform.Inline
+        PlutusIR.Transform.LetFloat
+        PlutusIR.Transform.LetMerge
+        PlutusIR.Transform.NonStrict
+        PlutusIR.Transform.RecSplit
+        PlutusIR.Transform.Rename
+        PlutusIR.Transform.Substitute
+        PlutusIR.Transform.ThunkRecursions
+        PlutusIR.Transform.Unwrap
+        PlutusIR.TypeCheck
+        PlutusPrelude
+        Prettyprinter.Custom
+        Universe
+        UntypedPlutusCore
+        UntypedPlutusCore.Check.Scope
+        UntypedPlutusCore.Check.Uniques
+        UntypedPlutusCore.Core
+        UntypedPlutusCore.Core.Type
+        UntypedPlutusCore.DeBruijn
+        UntypedPlutusCore.Evaluation.Machine.Cek
+        UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+        UntypedPlutusCore.MkUPlc
+        UntypedPlutusCore.Parser
+        UntypedPlutusCore.Rename
+
+    hs-source-dirs:
+        plutus-core/src plutus-core/stdlib plutus-core/examples
+        plutus-ir/src untyped-plutus-core/src prelude common
+
+    other-modules:
+        Data.Aeson.Flatten
+        Data.Aeson.THReader
+        Data.Functor.Foldable.Monadic
+        GHC.Natural.Extras
+        PlutusCore.Analysis.Definitions
+        PlutusCore.Builtin.HasConstant
+        PlutusCore.Builtin.KnownKind
+        PlutusCore.Builtin.KnownType
+        PlutusCore.Builtin.KnownTypeAst
+        PlutusCore.Builtin.Meaning
+        PlutusCore.Builtin.Polymorphism
+        PlutusCore.Builtin.Runtime
+        PlutusCore.Builtin.TestKnown
+        PlutusCore.Builtin.TypeScheme
+        PlutusCore.Core.Instance
+        PlutusCore.Core.Instance.Eq
+        PlutusCore.Core.Instance.Pretty
+        PlutusCore.Core.Instance.Pretty.Classic
+        PlutusCore.Core.Instance.Pretty.Common
+        PlutusCore.Core.Instance.Pretty.Default
+        PlutusCore.Core.Instance.Pretty.Plc
+        PlutusCore.Core.Instance.Pretty.Readable
+        PlutusCore.Core.Instance.Recursive
+        PlutusCore.Core.Instance.Scoping
+        PlutusCore.Core.Plated
+        PlutusCore.Core.Type
+        PlutusCore.DeBruijn.Internal
+        PlutusCore.Default.Builtins
+        PlutusCore.Default.Universe
+        PlutusCore.Eq
+        PlutusCore.InlineUtils
+        PlutusCore.Parser.ParserCommon
+        PlutusCore.Pretty.Classic
+        PlutusCore.Pretty.ConfigName
+        PlutusCore.Pretty.Default
+        PlutusCore.Pretty.Plc
+        PlutusCore.Pretty.PrettyConst
+        PlutusCore.Pretty.Readable
+        PlutusCore.Pretty.Utils
+        PlutusCore.Size
+        PlutusCore.TypeCheck
+        PlutusCore.TypeCheck.Internal
+        PlutusIR.Analysis.Dependencies
+        PlutusIR.Analysis.Size
+        PlutusIR.Analysis.Usages
+        PlutusIR.Compiler.Datatype
+        PlutusIR.Compiler.Error
+        PlutusIR.Compiler.Let
+        PlutusIR.Compiler.Lower
+        PlutusIR.Compiler.Provenance
+        PlutusIR.Compiler.Recursion
+        PlutusIR.Compiler.Types
+        PlutusIR.Normalize
+        PlutusIR.TypeCheck.Internal
+        Universe.Core
+        UntypedPlutusCore.Analysis.Definitions
+        UntypedPlutusCore.Analysis.Usages
+        UntypedPlutusCore.Core.Instance
+        UntypedPlutusCore.Core.Instance.Eq
+        UntypedPlutusCore.Core.Instance.Flat
+        UntypedPlutusCore.Core.Instance.Pretty
+        UntypedPlutusCore.Core.Instance.Pretty.Classic
+        UntypedPlutusCore.Core.Instance.Pretty.Default
+        UntypedPlutusCore.Core.Instance.Pretty.Plc
+        UntypedPlutusCore.Core.Instance.Pretty.Readable
+        UntypedPlutusCore.Core.Instance.Recursive
+        UntypedPlutusCore.Core.Plated
+        UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+        UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+        UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+        UntypedPlutusCore.Mark
+        UntypedPlutusCore.Rename.Internal
+        UntypedPlutusCore.Simplify
+        UntypedPlutusCore.Size
+        UntypedPlutusCore.Subst
+        UntypedPlutusCore.Transform.ForceDelay
+        UntypedPlutusCore.Transform.Inline
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        aeson,
+        algebraic-graphs >=0.3 && < 0.7,
+        array,
+        barbies,
+        base >=4.9 && <5,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-class,
+        cassava,
+        cborg,
+        composition-prelude >=1.1.0.1,
+        containers,
+        cryptonite,
+        data-default-class,
+        deepseq,
+        dependent-sum-template,
+        deriving-aeson >=0.2.3,
+        deriving-compat,
+        dlist,
+        dom-lt,
+        exceptions,
+        extra,
+        filepath,
+        flat,
+        ghc-prim,
+        hashable,
+        hedgehog >=1.0,
+        index-envs,
+        int-cast,
+        integer-gmp,
+        lens,
+        megaparsec,
+        mmorph,
+        monoidal-containers,
+        mtl,
+        nothunks,
+        parser-combinators >=0.4.0,
+        prettyprinter >=1.1.0.1,
+        prettyprinter-configurable,
+        primitive,
+        recursion-schemes,
+        semigroupoids,
+        semigroups >=0.19.1,
+        serialise,
+        some <1.0.3,
+        template-haskell,
+        text,
+        th-compat,
+        th-lift,
+        th-lift-instances,
+        th-utilities,
+        time,
+        transformers,
+        unordered-containers,
+        witherable,
+        word-array
+
+library plutus-core-testlib
+    exposed-modules:
+        PlutusCore.Generators
+        PlutusCore.Generators.AST
+        PlutusCore.Generators.Interesting
+        PlutusCore.Generators.NEAT.Common
+        PlutusCore.Generators.NEAT.Spec
+        PlutusCore.Generators.NEAT.Term
+        PlutusCore.Generators.NEAT.Type
+        PlutusCore.Generators.Test
+        PlutusCore.Test
+        PlutusIR.Generators.AST
+        PlutusIR.Test
+        Test.Tasty.Extras
+
+    visibility:         public
+    hs-source-dirs:     testlib
+    other-modules:
+        PlutusCore.Generators.Internal.Denotation
+        PlutusCore.Generators.Internal.Dependent
+        PlutusCore.Generators.Internal.Entity
+        PlutusCore.Generators.Internal.TypedBuiltinGen
+        PlutusCore.Generators.Internal.TypeEvalCheck
+        PlutusCore.Generators.Internal.Utils
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base >=4.9 && <5,
+        bifunctors,
+        bytestring,
+        containers,
+        dependent-map >=0.4.0.0,
+        filepath,
+        ghc-prim,
+        hedgehog >=1.0,
+        integer-gmp,
+        lazy-search,
+        lens,
+        megaparsec,
+        mmorph,
+        mtl,
+        plutus-core,
+        prettyprinter >=1.1.0.1,
+        prettyprinter-configurable,
+        size-based,
+        some <1.0.3,
+        Stream,
+        tasty,
+        tasty-golden,
+        tasty-hedgehog,
+        tasty-hunit,
+        text,
+        transformers
+
+library index-envs
+    exposed-modules:
+        Data.DeBruijnEnv
+        Data.RandomAccessList.SkewBinary
+
+    hs-source-dirs:     index-envs/src
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base,
+        containers,
+        ral ==0.1
+
+executable plc
+    main-is:            plc/Main.hs
+    hs-source-dirs:     executables
+    other-modules:
+        Common
+        Parsers
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        aeson,
+        base <5,
+        bytestring,
+        deepseq,
+        flat,
+        lens,
+        megaparsec,
+        monoidal-containers,
+        mtl,
+        optparse-applicative,
+        plutus-core,
+        plutus-core-testlib,
+        prettyprinter,
+        text,
+        transformers
+
+executable uplc
+    main-is:            uplc/Main.hs
+    hs-source-dirs:     executables
+    other-modules:
+        Common
+        Parsers
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        aeson,
+        base <5,
+        bytestring,
+        deepseq,
+        flat,
+        lens,
+        megaparsec,
+        monoidal-containers,
+        mtl,
+        optparse-applicative,
+        plutus-core,
+        plutus-core-testlib,
+        prettyprinter,
+        split,
+        text,
+        transformers
+
+executable pir
+    main-is:            pir/Main.hs
+    hs-source-dirs:     executables
+    other-modules:
+        Common
+        Parsers
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        aeson,
+        base <5,
+        bytestring,
+        cassava,
+        containers,
+        deepseq,
+        flat,
+        lens,
+        megaparsec,
+        monoidal-containers,
+        mtl,
+        optparse-applicative,
+        plutus-core,
+        plutus-core-testlib,
+        prettyprinter,
+        text,
+        transformers
+
+executable traceToStacks
+    main-is:            Main.hs
+    hs-source-dirs:     executables/traceToStacks
+    other-modules:      Common
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base >=4.9 && <5,
+        bytestring,
+        cassava,
+        integer-gmp,
+        optparse-applicative,
+        text,
+        vector
+
+test-suite satint-test
+    type:               exitcode-stdio-1.0
+    main-is:            TestSatInt.hs
+    hs-source-dirs:     plutus-core/satint-test
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -Wall
+
+    build-depends:
+        base >=4.9 && <5,
+        HUnit,
+        plutus-core,
+        QuickCheck,
+        test-framework,
+        test-framework-hunit,
+        test-framework-quickcheck2
+
+test-suite plutus-core-test
+    type:               exitcode-stdio-1.0
+    main-is:            Spec.hs
+    hs-source-dirs:     plutus-core/test
+    other-modules:
+        Check.Spec
+        CostModelInterface.Spec
+        Evaluation.Machines
+        Evaluation.Spec
+        Names.Spec
+        Normalization.Check
+        Normalization.Type
+        Pretty.Readable
+        TypeSynthesis.Spec
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -threaded -rtsopts
+        -with-rtsopts=-N
+
+    build-depends:
+        aeson,
+        base,
+        bytestring,
+        containers,
+        filepath,
+        flat,
+        hedgehog,
+        mmorph,
+        mtl,
+        plutus-core,
+        plutus-core-testlib,
+        prettyprinter,
+        tasty,
+        tasty-golden,
+        tasty-hedgehog,
+        tasty-hunit,
+        template-haskell,
+        text,
+        th-lift-instances,
+        th-utilities,
+        transformers
+
+test-suite plutus-ir-test
+    type:               exitcode-stdio-1.0
+    main-is:            Spec.hs
+    hs-source-dirs:     plutus-ir/test
+    other-modules:
+        NamesSpec
+        ParserSpec
+        TransformSpec
+        TypeSpec
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base >=4.9 && <5,
+        flat,
+        hedgehog,
+        megaparsec,
+        plutus-core,
+        plutus-core-testlib,
+        tasty,
+        tasty-hedgehog,
+        text
+
+test-suite untyped-plutus-core-test
+    type:               exitcode-stdio-1.0
+    main-is:            Spec.hs
+    hs-source-dirs:     untyped-plutus-core/test
+    other-modules:
+        DeBruijn.Common
+        DeBruijn.Scope
+        DeBruijn.Spec
+        DeBruijn.UnDeBruijnify
+        Evaluation.Builtins
+        Evaluation.Builtins.Coherence
+        Evaluation.Builtins.Common
+        Evaluation.Builtins.Definition
+        Evaluation.Builtins.MakeRead
+        Evaluation.Builtins.SECP256k1
+        Evaluation.FreeVars
+        Evaluation.Golden
+        Evaluation.Machines
+        Transform.Simplify
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -O2 -threaded
+        -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.9 && <5,
+        bytestring,
+        cardano-crypto-class,
+        hedgehog,
+        index-envs,
+        lens,
+        mtl,
+        plutus-core,
+        plutus-core-testlib,
+        pretty-show,
+        prettyprinter,
+        tasty,
+        tasty-golden,
+        tasty-hedgehog,
+        tasty-hunit,
+        text
+
+test-suite traceToStacks-test
+    type:               exitcode-stdio-1.0
+    main-is:            TestGetStacks.hs
+    hs-source-dirs:     executables/traceToStacks
+    other-modules:      Common
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base,
+        bytestring,
+        cassava,
+        tasty,
+        tasty-hunit,
+        text,
+        vector
+
+test-suite index-envs-test
+    type:               exitcode-stdio-1.0
+    main-is:            TestRAList.hs
+    hs-source-dirs:     index-envs/test
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base,
+        index-envs,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck
+
+benchmark cost-model-budgeting-bench
+    type:               exitcode-stdio-1.0
+    main-is:            Main.hs
+    hs-source-dirs:     cost-model/budgeting-bench
+    other-modules:
+        Benchmarks.Bool
+        Benchmarks.ByteStrings
+        Benchmarks.CryptoAndHashes
+        Benchmarks.Data
+        Benchmarks.Integers
+        Benchmarks.Lists
+        Benchmarks.Misc
+        Benchmarks.Nops
+        Benchmarks.Pairs
+        Benchmarks.Strings
+        Benchmarks.Tracing
+        Benchmarks.Unit
+        Common
+        CriterionExtensions
+        Generators
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -threaded -rtsopts
+        -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+    build-depends:
+        base,
+        bytestring,
+        criterion,
+        criterion-measurement,
+        deepseq,
+        directory,
+        hedgehog,
+        mtl,
+        optparse-applicative,
+        plutus-core,
+        QuickCheck,
+        quickcheck-instances,
+        random,
+        text
+
+benchmark update-cost-model
+    type:               exitcode-stdio-1.0
+    main-is:            UpdateCostModel.hs
+    hs-source-dirs:     cost-model/create-cost-model
+    other-modules:      CostModelCreation
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -threaded -rtsopts
+        -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+    build-depends:
+        aeson-pretty,
+        barbies,
+        base,
+        bytestring,
+        cassava,
+        exceptions,
+        extra,
+        inline-r,
+        plutus-core,
+        text,
+        vector
+
+benchmark cost-model-test
+    type:               exitcode-stdio-1.0
+    main-is:            TestCostModels.hs
+    hs-source-dirs:     cost-model/test cost-model/create-cost-model
+    other-modules:
+        TH
+        CostModelCreation
+
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies -threaded -rtsopts
+        -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+    build-depends:
+        barbies,
+        base,
+        bytestring,
+        cassava,
+        exceptions,
+        extra,
+        hedgehog,
+        inline-r,
+        mmorph,
+        plutus-core,
+        template-haskell,
+        text,
+        vector
+
+benchmark index-envs-bench
+    type:               exitcode-stdio-1.0
+    main-is:            Main.hs
+    hs-source-dirs:     index-envs/bench
+    default-language:   Haskell2010
+    default-extensions:
+        DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift
+        DeriveTraversable DerivingStrategies DerivingVia ExplicitForAll
+        FlexibleContexts GeneralizedNewtypeDeriving ImportQualifiedPost
+        ScopedTypeVariables StandaloneDeriving
+
+    ghc-options:
+        -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+        -Wincomplete-record-updates -Wredundant-constraints -Widentities
+        -Wunused-packages -Wmissing-deriving-strategies
+
+    build-depends:
+        base,
+        criterion >=1.5.9.0,
+        index-envs,
+        ral ==0.1,
+        random >=1.2.0

--- a/_sources/plutus-core/1.1.1.0/meta.toml
+++ b/_sources/plutus-core/1.1.1.0/meta.toml
@@ -4,3 +4,7 @@ subdir = 'plutus-core'
 [[revisions]]
   number = 1
   timestamp = 2023-02-22T19:09:40+00:00
+
+[[revisions]]
+number = 2
+timestamp = 2023-03-21T14:21:44Z

--- a/_sources/plutus-core/1.1.1.0/revisions/2.cabal
+++ b/_sources/plutus-core/1.1.1.0/revisions/2.cabal
@@ -1,0 +1,808 @@
+cabal-version:      3.0
+name:               plutus-core
+version:            1.1.1.0
+license:            Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:         michael.peyton-jones@iohk.io
+author:             Plutus Core Team
+synopsis:           Language library for Plutus Core
+description:        Pretty-printer, parser, and typechecker for Plutus Core.
+category:           Language, Plutus
+build-type:         Simple
+extra-doc-files:    README.md
+extra-source-files:
+  cost-model/data/*.R
+  cost-model/data/benching.csv
+  cost-model/data/builtinCostModel.json
+  cost-model/data/cekMachineCosts.json
+  plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/plutus
+
+-- inline-r is a problematic dependency. It doesn't build with newer
+-- versions of R, so if we depend on it then people need to install
+-- an old R. This is not so bad for people working on plutus itself
+-- (use Nix or work it out), although we may want to eventually
+-- purge it. However, due to a cabal bug (https://github.com/haskell/cabal/issues/4087),
+-- in some cases cabal will require R to be installed _at solving time_,
+-- even though it never wants to build it. This means that the problem
+-- leaks into our downstream dependencies. So our solution is to guard
+-- the dependency behind a flag, off by default, and turn it on for
+-- ourselves locally.
+flag with-inline-r
+  description: Enable build of packages that use `inline-r`.
+  manual:      True
+  default:     False
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
+
+library
+  import:          lang
+  exposed-modules:
+    Crypto
+    Data.ByteString.Hash
+    Data.Either.Extras
+    Data.MultiSet.Lens
+    Data.SatInt
+    ErrorCode
+    PlutusCore
+    PlutusCore.Builtin
+    PlutusCore.Builtin.Debug
+    PlutusCore.Builtin.Elaborate
+    PlutusCore.Builtin.Emitter
+    PlutusCore.Check.Normal
+    PlutusCore.Check.Scoping
+    PlutusCore.Check.Uniques
+    PlutusCore.Check.Value
+    PlutusCore.Compiler
+    PlutusCore.Compiler.Erase
+    PlutusCore.Core
+    PlutusCore.Data
+    PlutusCore.DataFilePaths
+    PlutusCore.DeBruijn
+    PlutusCore.Default
+    PlutusCore.Error
+    PlutusCore.Evaluation.Machine.BuiltinCostModel
+    PlutusCore.Evaluation.Machine.Ck
+    PlutusCore.Evaluation.Machine.CostingFun.Core
+    PlutusCore.Evaluation.Machine.CostingFun.JSON
+    PlutusCore.Evaluation.Machine.CostModelInterface
+    PlutusCore.Evaluation.Machine.ExBudget
+    PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+    PlutusCore.Evaluation.Machine.Exception
+    PlutusCore.Evaluation.Machine.ExMemory
+    PlutusCore.Evaluation.Machine.MachineParameters
+    PlutusCore.Evaluation.Machine.MachineParameters.Default
+    PlutusCore.Evaluation.Machine.MachineParameters.DeferredMachineParameters
+    PlutusCore.Evaluation.Machine.MachineParameters.ImmediateMachineParameters
+    PlutusCore.Evaluation.Result
+    PlutusCore.Examples.Builtins
+    PlutusCore.Examples.Data.Data
+    PlutusCore.Examples.Data.InterList
+    PlutusCore.Examples.Data.List
+    PlutusCore.Examples.Data.Pair
+    PlutusCore.Examples.Data.Shad
+    PlutusCore.Examples.Data.TreeForest
+    PlutusCore.Examples.Data.Vec
+    PlutusCore.Examples.Everything
+    PlutusCore.Flat
+    PlutusCore.FsTree
+    PlutusCore.Mark
+    PlutusCore.MkPlc
+    PlutusCore.Name
+    PlutusCore.Normalize
+    PlutusCore.Normalize.Internal
+    PlutusCore.Parser
+    PlutusCore.Pretty
+    PlutusCore.Quote
+    PlutusCore.Rename
+    PlutusCore.Rename.Internal
+    PlutusCore.Rename.Monad
+    PlutusCore.StdLib.Data.Bool
+    PlutusCore.StdLib.Data.ChurchNat
+    PlutusCore.StdLib.Data.Data
+    PlutusCore.StdLib.Data.Function
+    PlutusCore.StdLib.Data.Integer
+    PlutusCore.StdLib.Data.List
+    PlutusCore.StdLib.Data.Nat
+    PlutusCore.StdLib.Data.Pair
+    PlutusCore.StdLib.Data.ScottList
+    PlutusCore.StdLib.Data.ScottUnit
+    PlutusCore.StdLib.Data.Sum
+    PlutusCore.StdLib.Data.Unit
+    PlutusCore.StdLib.Everything
+    PlutusCore.StdLib.Meta
+    PlutusCore.StdLib.Meta.Data.Function
+    PlutusCore.StdLib.Meta.Data.Tuple
+    PlutusCore.StdLib.Type
+    PlutusCore.Subst
+    PlutusCore.TypeCheck
+    PlutusCore.TypeCheck.Internal
+    PlutusIR
+    PlutusIR.Analysis.RetainedSize
+    PlutusIR.Compiler
+    PlutusIR.Compiler.Datatype
+    PlutusIR.Compiler.Definitions
+    PlutusIR.Compiler.Names
+    PlutusIR.Core
+    PlutusIR.Core.Instance
+    PlutusIR.Core.Instance.Flat
+    PlutusIR.Core.Instance.Pretty
+    PlutusIR.Core.Instance.Pretty.Readable
+    PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Plated
+    PlutusIR.Core.Type
+    PlutusIR.Error
+    PlutusIR.Mark
+    PlutusIR.MkPir
+    PlutusIR.Parser
+    PlutusIR.Purity
+    PlutusIR.Subst
+    PlutusIR.Transform.Beta
+    PlutusIR.Transform.DeadCode
+    PlutusIR.Transform.Inline
+    PlutusIR.Transform.LetFloat
+    PlutusIR.Transform.LetMerge
+    PlutusIR.Transform.NonStrict
+    PlutusIR.Transform.RecSplit
+    PlutusIR.Transform.Rename
+    PlutusIR.Transform.Substitute
+    PlutusIR.Transform.ThunkRecursions
+    PlutusIR.Transform.Unwrap
+    PlutusIR.TypeCheck
+    PlutusIR.TypeCheck.Internal
+    PlutusPrelude
+    Prettyprinter.Custom
+    Universe
+    UntypedPlutusCore
+    UntypedPlutusCore.Check.Scope
+    UntypedPlutusCore.Check.Uniques
+    UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.DeBruijn
+    UntypedPlutusCore.Evaluation.Machine.Cek
+    UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    UntypedPlutusCore.MkUPlc
+    UntypedPlutusCore.Parser
+    UntypedPlutusCore.Rename
+
+  hs-source-dirs:
+    plutus-core/src plutus-core/stdlib plutus-core/examples
+    plutus-ir/src untyped-plutus-core/src prelude common
+
+  other-modules:
+    Data.Aeson.Flatten
+    Data.Aeson.THReader
+    Data.Functor.Foldable.Monadic
+    GHC.Natural.Extras
+    PlutusCore.Analysis.Definitions
+    PlutusCore.Builtin.HasConstant
+    PlutusCore.Builtin.KnownKind
+    PlutusCore.Builtin.KnownType
+    PlutusCore.Builtin.KnownTypeAst
+    PlutusCore.Builtin.Meaning
+    PlutusCore.Builtin.Polymorphism
+    PlutusCore.Builtin.Runtime
+    PlutusCore.Builtin.TestKnown
+    PlutusCore.Builtin.TypeScheme
+    PlutusCore.Core.Instance
+    PlutusCore.Core.Instance.Eq
+    PlutusCore.Core.Instance.Pretty
+    PlutusCore.Core.Instance.Pretty.Classic
+    PlutusCore.Core.Instance.Pretty.Common
+    PlutusCore.Core.Instance.Pretty.Default
+    PlutusCore.Core.Instance.Pretty.Plc
+    PlutusCore.Core.Instance.Pretty.Readable
+    PlutusCore.Core.Instance.Recursive
+    PlutusCore.Core.Instance.Scoping
+    PlutusCore.Core.Plated
+    PlutusCore.Core.Type
+    PlutusCore.DeBruijn.Internal
+    PlutusCore.Default.Builtins
+    PlutusCore.Default.Universe
+    PlutusCore.Eq
+    PlutusCore.InlineUtils
+    PlutusCore.Parser.Builtin
+    PlutusCore.Parser.ParserCommon
+    PlutusCore.Parser.Type
+    PlutusCore.Pretty.Classic
+    PlutusCore.Pretty.ConfigName
+    PlutusCore.Pretty.Default
+    PlutusCore.Pretty.Extra
+    PlutusCore.Pretty.Plc
+    PlutusCore.Pretty.PrettyConst
+    PlutusCore.Pretty.Readable
+    PlutusCore.Pretty.Utils
+    PlutusCore.Size
+    PlutusIR.Analysis.Dependencies
+    PlutusIR.Analysis.Size
+    PlutusIR.Analysis.Usages
+    PlutusIR.Compiler.Error
+    PlutusIR.Compiler.Let
+    PlutusIR.Compiler.Lower
+    PlutusIR.Compiler.Provenance
+    PlutusIR.Compiler.Recursion
+    PlutusIR.Compiler.Types
+    PlutusIR.Normalize
+    Universe.Core
+    UntypedPlutusCore.Analysis.Definitions
+    UntypedPlutusCore.Analysis.Usages
+    UntypedPlutusCore.Core.Instance
+    UntypedPlutusCore.Core.Instance.Eq
+    UntypedPlutusCore.Core.Instance.Flat
+    UntypedPlutusCore.Core.Instance.Pretty
+    UntypedPlutusCore.Core.Instance.Pretty.Classic
+    UntypedPlutusCore.Core.Instance.Pretty.Default
+    UntypedPlutusCore.Core.Instance.Pretty.Plc
+    UntypedPlutusCore.Core.Instance.Pretty.Readable
+    UntypedPlutusCore.Core.Instance.Recursive
+    UntypedPlutusCore.Core.Plated
+    UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+    UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+    UntypedPlutusCore.Mark
+    UntypedPlutusCore.Rename.Internal
+    UntypedPlutusCore.Simplify
+    UntypedPlutusCore.Size
+    UntypedPlutusCore.Subst
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
+
+  -- Bound on cardano-crypto-class for the fixed SECP primitives
+  build-depends:
+    , aeson
+    , algebraic-graphs            >=0.7
+    , array
+    , barbies
+    , base                        >=4.9     && <5
+    , base64-bytestring
+    , bimap
+    , bytestring
+    , cardano-crypto
+    , cardano-crypto-class        ^>= { 2.0.0.1, 2.1 }
+    , cassava
+    , cborg
+    , composition-prelude         >=1.1.0.1
+    , containers
+    , cryptonite
+    , data-default-class
+    , deepseq
+    , dependent-sum-template
+    , dependent-sum               >= 0.7.1.0
+    , deriving-aeson              >=0.2.3
+    , deriving-compat
+    , dlist
+    , dom-lt
+    , exceptions
+    , extra
+    , filepath
+    , flat
+    , ghc-prim
+    , hashable                    >=1.4
+    , hedgehog                    >=1.0
+    , index-envs
+    , int-cast
+    , lens
+    , megaparsec
+    , mmorph
+    , monoidal-containers
+    , mtl
+    , multiset
+    , nothunks                    >=0.1.1
+    , parser-combinators          >=0.4.0
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable  ^>=1.1
+    , primitive
+    , recursion-schemes
+    , semigroupoids
+    , semigroups                  >=0.19.1
+    , serialise
+    , some
+    , template-haskell
+    , text
+    , th-compat
+    , th-lift
+    , th-lift-instances
+    , th-utilities
+    , time
+    , transformers
+    , unordered-containers
+    , witherable
+    , word-array                  ^>=1.1
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+-- could split this up if we split up the main library for UPLC/PLC/PIR
+library plutus-core-testlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  testlib
+  exposed-modules:
+    PlutusCore.Generators.Hedgehog
+    PlutusCore.Generators.Hedgehog.AST
+    PlutusCore.Generators.Hedgehog.Builtin
+    PlutusCore.Generators.Hedgehog.Denotation
+    PlutusCore.Generators.Hedgehog.Entity
+    PlutusCore.Generators.Hedgehog.Interesting
+    PlutusCore.Generators.Hedgehog.Test
+    PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+    PlutusCore.Generators.Hedgehog.TypeEvalCheck
+    PlutusCore.Generators.Hedgehog.Utils
+    PlutusCore.Generators.NEAT.Common
+    PlutusCore.Generators.NEAT.Spec
+    PlutusCore.Generators.NEAT.Term
+    PlutusCore.Generators.NEAT.Type
+    PlutusCore.Generators.QuickCheck
+    PlutusCore.Generators.QuickCheck.Builtin
+    PlutusCore.Generators.QuickCheck.Common
+    PlutusCore.Generators.QuickCheck.GenerateKinds
+    PlutusCore.Generators.QuickCheck.GenerateTypes
+    PlutusCore.Generators.QuickCheck.GenTm
+    PlutusCore.Generators.QuickCheck.ShrinkTypes
+    PlutusCore.Generators.QuickCheck.Substitutions
+    PlutusCore.Generators.QuickCheck.Unification
+    PlutusCore.Generators.QuickCheck.Utils
+    PlutusCore.Test
+    PlutusIR.Generators.AST
+    PlutusIR.Test
+    Test.Tasty.Extras
+
+  build-depends:
+    , base                        >=4.9     && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , dependent-map               >=0.4.0.0
+    , filepath
+    , hedgehog                    >=1.0
+    , lazy-search
+    , lens
+    , mmorph
+    , mtl
+    , multiset
+    , plutus-core                 ^>=1.1
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , QuickCheck
+    , quickcheck-transformer
+    , size-based
+    , Stream
+    , tagged
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+
+test-suite satint-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestSatInt.hs
+  build-depends:
+    , base                        >=4.9 && <5
+    , HUnit
+    , plutus-core                 ^>=1.1
+    , QuickCheck
+    , test-framework
+    , test-framework-hunit
+    , test-framework-quickcheck2
+
+  default-language: Haskell2010
+  hs-source-dirs:   plutus-core/satint-test
+
+test-suite plutus-core-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   plutus-core/test
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    CBOR.DataStability
+    Check.Spec
+    CostModelInterface.Spec
+    Evaluation.Machines
+    Evaluation.Spec
+    Names.Spec
+    Normalization.Check
+    Normalization.Type
+    Pretty.Readable
+    TypeSynthesis.Spec
+
+  default-language: Haskell2010
+  build-depends:
+    , aeson
+    , base                 >=4.9 && <5
+    , bytestring
+    , containers
+    , data-default-class
+    , filepath
+    , flat
+    , hedgehog
+    , hex-text
+    , mmorph
+    , mtl
+    , plutus-core          ^>=1.1
+    , plutus-core-testlib  ^>=1.1
+    , prettyprinter
+    , serialise
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , template-haskell
+    , text
+    , th-lift-instances
+    , th-utilities
+
+test-suite plutus-ir-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: plutus-ir/test
+  other-modules:
+    GeneratorSpec
+    GeneratorSpec.Substitution
+    GeneratorSpec.Types
+    NamesSpec
+    ParserSpec
+    TransformSpec
+    TypeSpec
+
+  build-depends:
+    , base                 >=4.9 && <5
+    , containers
+    , flat
+    , hedgehog
+    , lens
+    , megaparsec
+    , plutus-core          ^>=1.1
+    , plutus-core-testlib  ^>=1.1
+    , QuickCheck
+    , tasty
+    , tasty-hedgehog
+    , tasty-quickcheck
+    , text
+
+test-suite untyped-plutus-core-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: untyped-plutus-core/test
+  ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    DeBruijn.Common
+    DeBruijn.Scope
+    DeBruijn.Spec
+    DeBruijn.UnDeBruijnify
+    Evaluation.Builtins
+    Evaluation.Builtins.Common
+    Evaluation.Builtins.Definition
+    Evaluation.Builtins.MakeRead
+    Evaluation.Builtins.SignatureVerification
+    Evaluation.FreeVars
+    Evaluation.Golden
+    Evaluation.Machines
+    Evaluation.Regressions
+    Generators
+    Transform.Simplify
+
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cardano-crypto-class
+    , flat
+    , hedgehog
+    , index-envs
+    , lens
+    , mtl
+    , plutus-core           ^>=1.1
+    , plutus-core-testlib   ^>=1.1
+    , pretty-show
+    , prettyprinter
+    , split
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+
+executable plc
+  import:         lang
+  main-is:        plc/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  >=4.9 && <5
+    , bytestring
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core           ^>=1.1
+    , plutus-core-testlib   ^>=1.1
+    , prettyprinter
+    , text
+
+executable uplc
+  import:         lang
+  main-is:        uplc/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  >=4.9 && <5
+    , bytestring
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core           ^>=1.1
+    , plutus-core-testlib   ^>=1.1
+    , prettyprinter
+    , split
+    , text
+
+executable pir
+  import:         lang
+  main-is:        pir/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , containers
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core           ^>=1.1
+    , plutus-core-testlib   ^>=1.1
+    , prettyprinter
+    , text
+    , transformers
+
+executable traceToStacks
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: executables/traceToStacks
+  other-modules:  Common
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , optparse-applicative
+    , text
+    , vector
+
+-- Tests for functions called by @traceToStacks@.
+test-suite traceToStacks-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   executables/traceToStacks
+  default-language: Haskell2010
+  main-is:          TestGetStacks.hs
+  other-modules:    Common
+  build-depends:
+    , base         >=4.9 && <5
+    , bytestring
+    , cassava
+    , tasty
+    , tasty-hunit
+    , text
+    , vector
+
+-- This runs the microbenchmarks used to generate the cost models for built-in
+-- functions, saving the results in a CSV file which must be specified on the
+-- commmand line.  It will take several hours.
+executable cost-model-budgeting-bench
+  import:         lang
+  main-is:        Main.hs
+  other-modules:
+    Benchmarks.Bool
+    Benchmarks.ByteStrings
+    Benchmarks.CryptoAndHashes
+    Benchmarks.Data
+    Benchmarks.Integers
+    Benchmarks.Lists
+    Benchmarks.Misc
+    Benchmarks.Nops
+    Benchmarks.Pairs
+    Benchmarks.Strings
+    Benchmarks.Tracing
+    Benchmarks.Unit
+    Common
+    CriterionExtensions
+    Generators
+
+  hs-source-dirs: cost-model/budgeting-bench
+  build-depends:
+    , base                   >=4.9 && <5
+    , bytestring
+    , cardano-crypto-class
+    , criterion
+    , criterion-measurement
+    , deepseq
+    , directory
+    , filepath
+    , hedgehog
+    , mtl
+    , optparse-applicative
+    , plutus-core            ^>=1.1
+    , QuickCheck
+    , quickcheck-instances
+    , random
+    , text
+    , time
+
+-- This reads CSV data generated by cost-model-budgeting-bench, uses R to build
+-- the cost models for built-in functions, and saves them in a specified
+-- JSON file (see the help).  The 'official' cost model should be checked in
+-- in plutus-core/cost-model/data/builtinCostModel.json.
+executable generate-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/create-cost-model
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  build-depends:
+    , aeson-pretty
+    , barbies
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , directory
+    , exceptions
+    , extra
+    , inline-r
+    , optparse-applicative
+    , plutus-core           ^>=1.1
+    , text
+    , vector
+
+  other-modules:  CreateBuiltinCostModel
+
+-- The cost models for builtins are generated using R and converted into a JSON
+-- form that can later be used to construct Haskell functions.  This tests that
+-- the predictions of the Haskell version are (approximately) identical to the R
+-- ones.  This test is problematic in CI: pretending that it's a benchmark will
+-- prevent it from being run automatically but will still allow us to run it
+-- manually; `cabal bench` also sets the working directory to the root of the
+-- relevant package, which makes it easier to find the cost model data files
+-- (unlike `cabal run` for exectuables, which sets the working directory to the
+-- current shell directory).
+benchmark cost-model-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        TestCostModels.hs
+  other-modules:  TH
+  hs-source-dirs: cost-model/test cost-model/create-cost-model
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  build-depends:
+    , barbies
+    , base              >=4.9 && <5
+    , bytestring
+    , cassava
+    , exceptions
+    , extra
+    , hedgehog
+    , inline-r
+    , mmorph
+    , plutus-core       ^>=1.1
+    , template-haskell
+    , text
+    , vector
+
+  other-modules:  CreateBuiltinCostModel
+
+executable print-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/print-cost-model
+  other-modules:  Paths_plutus_core
+  build-depends:
+    , aeson
+    , base        >=4.9 && <5
+    , bytestring
+    , text
+
+library index-envs
+  import:           lang
+  hs-source-dirs:   index-envs/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.RandomAccessList.Class
+    Data.RandomAccessList.RelativizedMap
+    Data.RandomAccessList.SkewBinary
+    Data.RandomAccessList.SkewBinarySlab
+
+  build-depends:
+    , base             >=4.9 && <5
+    , containers
+    , extra
+    , nonempty-vector
+    , ral              ^>=0.2
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+benchmark index-envs-bench
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/bench
+  default-language: Haskell2010
+  main-is:          Main.hs
+  build-depends:
+    , base             >=4.9     && <5
+    , criterion        >=1.5.9.0
+    , index-envs
+    , nonempty-vector
+    , ral              ^>=0.2
+    , random           >=1.2.0
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+test-suite index-envs-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/test
+  default-language: Haskell2010
+  main-is:          Spec.hs
+  other-modules:    RAList.Spec
+  build-depends:
+    , base                  >=4.9 && <5
+    , index-envs
+    , nonempty-vector
+    , QuickCheck
+    , quickcheck-instances
+    , tasty
+    , tasty-quickcheck

--- a/_sources/quickcheck-contractmodel/0.1.2.0/meta.toml
+++ b/_sources/quickcheck-contractmodel/0.1.2.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-24T06:30:00Z
 github = { repo = "input-output-hk/quickcheck-contractmodel", rev = "071628000ad391ba6849b4d8407b5375228d235d" }
 subdir = 'quickcheck-contractmodel'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:40:22Z

--- a/_sources/quickcheck-contractmodel/0.1.2.0/revisions/1.cabal
+++ b/_sources/quickcheck-contractmodel/0.1.2.0/revisions/1.cabal
@@ -1,0 +1,104 @@
+cabal-version:      2.4
+name:               quickcheck-contractmodel
+version:            0.1.2.0
+
+-- A short (one-line) description of the package.
+-- synopsis:
+
+-- A longer description of the package.
+-- description:
+
+-- A URL where users can report bugs.
+-- bug-reports:
+
+-- The license under which the package is released.
+-- license:
+author:             Maximilian Algehed
+maintainer:         maximilian.algehed@quviq.com
+
+-- A copyright notice.
+-- copyright:
+-- category:
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    FunctionalDependencies
+    RecordWildCards
+    ViewPatterns
+    DeriveFunctor
+    DeriveDataTypeable
+    StandaloneDeriving
+    ImportQualifiedPost
+    TupleSections
+    LambdaCase
+    PatternSynonyms
+    GADTs
+    TypeApplications
+    ScopedTypeVariables
+    TypeFamilies
+    FlexibleContexts
+    FlexibleInstances
+    MultiParamTypeClasses
+    RankNTypes
+    GeneralizedNewtypeDeriving
+    PolyKinds
+    TemplateHaskell
+    DataKinds
+    DefaultSignatures
+    ConstraintKinds
+    DeriveGeneric
+    DerivingVia
+    TypeOperators
+    OverloadedStrings
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities -Wno-name-shadowing
+    -Wno-orphans -Wno-redundant-constraints
+
+library
+    import: lang
+    hs-source-dirs: src
+    exposed-modules:
+      Test.QuickCheck.ContractModel
+      Test.QuickCheck.ContractModel.DL
+      Test.QuickCheck.ContractModel.Internal
+      Test.QuickCheck.ContractModel.Internal.Model
+      Test.QuickCheck.ContractModel.Internal.Common
+      Test.QuickCheck.ContractModel.Internal.ChainIndex
+      Test.QuickCheck.ContractModel.Internal.Spec
+      Test.QuickCheck.ContractModel.Internal.Symbolics
+      Test.QuickCheck.ContractModel.Internal.Utils
+      Test.QuickCheck.ContractModel.ThreatModel
+      Test.QuickCheck.ContractModel.ThreatModel.Cardano.Api
+      Test.QuickCheck.ContractModel.ThreatModel.DoubleSatisfaction
+      Test.QuickCheck.ContractModel.ThreatModel.Pretty
+      Test.QuickCheck.ContractModel.ThreatModel.TxModifier
+    -- General dependencies
+    build-depends:
+      base >=4.7 && <5,
+      bytestring ^>= 0.10.12,
+      containers ^>= 0.6.5.1,
+      lens ^>= 5.2,
+      mmorph ^>= 1.2,
+      mtl ^>= 2.2.2,
+      pretty ^>= 1.1.3.6,
+      time ^>= 1.9.3,
+    -- QuickCheck dependencies
+      QuickCheck ^>= 2.14,
+      quickcheck-dynamic >= 3.0.2,
+    -- Plutus and Cardano dependencies
+    build-depends:
+      plutus-tx ^>= 1.0,
+      cardano-api ^>= 1.35.4,
+      cardano-ledger-core ^>= 0.1,
+      cardano-ledger-alonzo ^>= 0.1,
+      cardano-ledger-shelley ^>= 0.1,
+      cardano-ledger-shelley-ma ^>= 0.1,
+      cardano-ledger-babbage ^>= 0.1,
+      cardano-slotting ^>= 0.1,
+      ouroboros-consensus ^>= 0.1.0.1,
+      ouroboros-consensus-cardano ^>= 0.1.0.1,
+      strict-containers ^>= 0.1,

--- a/_sources/typed-protocols/0.1.0.1/meta.toml
+++ b/_sources/typed-protocols/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-26T11:25:05Z
 github = { repo = "input-output-hk/typed-protocols", rev = "c5e87c9ba2854966794f04c5c2887faa09bf2214" }
 subdir = 'typed-protocols'
+
+[[revisions]]
+number = 1
+timestamp = 2023-03-21T14:31:13Z

--- a/_sources/typed-protocols/0.1.0.1/revisions/1.cabal
+++ b/_sources/typed-protocols/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,48 @@
+name:                typed-protocols
+version:             0.1.0.1
+synopsis:            A framework for strongly typed protocols
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2019 Input Output (Hong Kong) Ltd.
+author:              Alexander Vieth, Duncan Coutts, Marcin Szamotulski
+maintainer:          alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io
+category:            Control
+build-type:          Simple
+
+-- These should probably be added at some point.
+-- extra-source-files:  ChangeLog.md, README.md
+
+cabal-version:       >=1.10
+
+library
+  exposed-modules:   Network.TypedProtocol
+                   , Network.TypedProtocol.Core
+                   , Network.TypedProtocol.Codec
+                   , Network.TypedProtocol.Pipelined
+                   , Network.TypedProtocol.Driver
+                   , Network.TypedProtocol.Proofs
+
+  other-extensions:  GADTs
+                   , RankNTypes
+                   , PolyKinds
+                   , DataKinds
+                   , ScopedTypeVariables
+                   , TypeFamilies
+                   , TypeOperators
+                   , BangPatterns
+  build-depends:     base,
+                     io-classes >= 0.3
+
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  ghc-options:       -Wall
+                     -Wno-unticked-promoted-constructors
+                     -Wcompat
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,8 @@
             "ouroboros-consensus-cardano" 
             "cardano-api" 
             "cardano-node" 
+            # from plutus-apps
+            "plutus-ledger" 
             ];
           # using intersectAttrs like this is a cheap way to throw away everything with keys not in
           # smokeTestPackages
@@ -96,7 +98,11 @@
               perCompilerDerivations = lib.recurseIntoAttrs (lib.genAttrs compilers derivations);
               # cardano-node/cardano-api can't build on 9.2 yet
               # TODO: work out a better way of doing these exclusions
-              toRemove = [ (lib.setAttrByPath [ "ghc926" "cardano-api" ] null) (lib.setAttrByPath [ "ghc926" "cardano-node" ] null) ];
+              toRemove = [ 
+                (lib.setAttrByPath [ "ghc926" "cardano-api" ] null) 
+                (lib.setAttrByPath [ "ghc926" "cardano-node" ] null) 
+                (lib.setAttrByPath [ "ghc926" "plutus-ledger" ] null) 
+              ];
               filtered = builtins.foldl' lib.recursiveUpdate perCompilerDerivations toRemove;
             in flake-utils.lib.flattenTree filtered;
 

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -43,6 +43,11 @@ let
             url: https://input-output-hk.github.io/cardano-haskell-packages
             secure: True
 
+          -- cardano-node depends on ekg, which has an unnecessarily tight
+          -- lower bound on aeson, see https://github.com/tibbe/ekg/issues/90
+          -- We need to fix this upstream, or patch it in CHaP
+          allow-newer: ekg:aeson
+
           extra-packages: ${package-id}
         '';
 

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -4,6 +4,14 @@ let
   inherit (pkgs) lib;
   inherit (pkgs.haskell-nix) haskellLib;
 
+  # Build all the derivations that we care about for a package-version.
+  #
+  # Note that this is not-cheap in two ways:
+  # 1. Each invocation of this function will incur some IFD to run the
+  # cabal solver to create a build plan.
+  # 2. Since each invocation of this has its own build plan, there is
+  # little chance that derivations will actually be shared between 
+  # invocations.
   build-chap-package = package-name: package-version:
     let
       package-id = "${package-name}-${package-version}";


### PR DESCRIPTION
This extends the smoke-test package builder to build the newest versions of:
- `plutus-ledger-api`
- `cardano-ledger-api`
- `ouroboros-network`
- `ouroboros-consensus-cardano`
- `cardano-api`
- `cardano-node`

To make all this work I had to do a _lot_ of revisions. I took the hard but hopefully thorough route of just keeping trying to build things and then revising whatever the problem with the particular package that failed to build was. That meant a lot of"add an upper bound to foo-X -> cabal picks foo-Y -> add an upper bound to foo-Y -> ..., but I got there eventually.

The revisions are obviously very hard to review at the moment, so I guess you'll just have to trust me. If anyone wants to spot-check, I tried to list in the commit message what the revision was.

There is only one bit of global config I added: `allow-newer: ekg:json`. `cardano-node` needs it, upstream seems dead, we should probably just patch it in CHaP so we can bin that.

Note that this means that in future the CI will block new releases of these packages unless they build cleanly!