### PR TITLE
New revisions of ouroboros-consensus-shelley and cardano-ledger-shelley

### DIFF
--- a/_sources/cardano-ledger-shelley/0.1.0.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-shelley/0.1.0.0/revisions/3.cabal
@@ -1,0 +1,119 @@
+cabal-version: 2.2
+
+name:                cardano-ledger-shelley
+version:             0.1.0.0
+description:         Shelley Ledger Executable Model
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger.git
+  subdir:   eras/shelley/impl
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wpartial-fields
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+  exposed-modules:
+    Cardano.Ledger.Chain
+    Cardano.Ledger.Shelley
+    Cardano.Ledger.Shelley.Constraints
+    Cardano.Ledger.Shelley.Address.Bootstrap
+    Cardano.Ledger.Shelley.API
+    Cardano.Ledger.Shelley.API.ByronTranslation
+    Cardano.Ledger.Shelley.API.Genesis
+    Cardano.Ledger.Shelley.API.Validation
+    Cardano.Ledger.Shelley.API.Wallet
+    Cardano.Ledger.Shelley.API.Mempool
+    Cardano.Ledger.Shelley.API.Types
+    Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.BlockChain
+    Cardano.Ledger.Shelley.CompactAddr
+    Cardano.Ledger.Shelley.Delegation.Certificates
+    Cardano.Ledger.Shelley.Delegation.PoolParams
+    Cardano.Ledger.Shelley.EpochBoundary
+    Cardano.Ledger.Shelley.Genesis
+    Cardano.Ledger.Shelley.HardForks
+    Cardano.Ledger.Shelley.LedgerState
+    Cardano.Ledger.Shelley.Metadata
+    Cardano.Ledger.Shelley.Orphans
+    Cardano.Ledger.Shelley.PoolRank
+    Cardano.Ledger.Shelley.PParams
+    Cardano.Ledger.Shelley.Rewards
+    Cardano.Ledger.Shelley.RewardProvenance
+    Cardano.Ledger.Shelley.RewardUpdate
+    Cardano.Ledger.Shelley.Scripts
+    Cardano.Ledger.Shelley.SoftForks
+    Cardano.Ledger.Shelley.StabilityWindow
+    Cardano.Ledger.Shelley.Rules.Bbody
+    Cardano.Ledger.Shelley.Rules.Deleg
+    Cardano.Ledger.Shelley.Rules.Delegs
+    Cardano.Ledger.Shelley.Rules.Delpl
+    Cardano.Ledger.Shelley.Rules.Epoch
+    Cardano.Ledger.Shelley.Rules.EraMapping
+    Cardano.Ledger.Shelley.Rules.Ledger
+    Cardano.Ledger.Shelley.Rules.Ledgers
+    Cardano.Ledger.Shelley.Rules.Mir
+    Cardano.Ledger.Shelley.Rules.NewEpoch
+    Cardano.Ledger.Shelley.Rules.Newpp
+    Cardano.Ledger.Shelley.Rules.Pool
+    Cardano.Ledger.Shelley.Rules.PoolReap
+    Cardano.Ledger.Shelley.Rules.Ppup
+    Cardano.Ledger.Shelley.Rules.Rupd
+    Cardano.Ledger.Shelley.Rules.Snap
+    Cardano.Ledger.Shelley.Rules.Tick
+    Cardano.Ledger.Shelley.Rules.Upec
+    Cardano.Ledger.Shelley.Rules.Utxo
+    Cardano.Ledger.Shelley.Rules.Utxow
+    Cardano.Ledger.Shelley.Tx
+    Cardano.Ledger.Shelley.TxBody
+    Cardano.Ledger.Shelley.UTxO
+  hs-source-dirs: src
+  build-depends:
+    aeson >= 2,
+    base16-bytestring >= 1,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data < 0.2.0.0, 
+    cardano-ledger-byron,
+    cardano-ledger-core,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    vector-map < 1,
+    constraints,
+    containers,
+    data-default-class,
+    deepseq,
+    groups,
+    iproute,
+    mtl,
+    microlens,
+    nothunks,
+    quiet,
+    set-algebra,
+    small-steps,
+    strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,
+

--- a/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/3.cabal
+++ b/_sources/ouroboros-consensus-shelley/0.1.0.1/revisions/3.cabal
@@ -1,0 +1,101 @@
+name:                  ouroboros-consensus-shelley
+version:               0.1.0.1
+synopsis:              Shelley ledger integration in the Ouroboros consensus layer
+-- description:
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2019 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Ouroboros.Consensus.Shelley.Crypto
+                       Ouroboros.Consensus.Shelley.Eras
+                       Ouroboros.Consensus.Shelley.HFEras
+                       Ouroboros.Consensus.Shelley.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Block
+                       Ouroboros.Consensus.Shelley.Ledger.Config
+                       Ouroboros.Consensus.Shelley.Ledger.Forge
+                       Ouroboros.Consensus.Shelley.Ledger.Inspect
+                       Ouroboros.Consensus.Shelley.Ledger.Integrity
+                       Ouroboros.Consensus.Shelley.Ledger.Ledger
+                       Ouroboros.Consensus.Shelley.Ledger.Mempool
+                       Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+                       Ouroboros.Consensus.Shelley.Ledger.Query
+                       Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+                       Ouroboros.Consensus.Shelley.Ledger.Protocol
+                       Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+                       Ouroboros.Consensus.Shelley.Node
+                       Ouroboros.Consensus.Shelley.Node.Common
+                       Ouroboros.Consensus.Shelley.Node.Praos
+                       Ouroboros.Consensus.Shelley.Node.TPraos
+                       Ouroboros.Consensus.Shelley.Node.Serialisation
+                       Ouroboros.Consensus.Shelley.Protocol.Abstract
+                       Ouroboros.Consensus.Shelley.Protocol.Praos
+                       Ouroboros.Consensus.Shelley.Protocol.TPraos
+                       Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  build-depends:       base              >=4.9   && <4.15
+                     , base-deriving-via
+                     , bytestring        >=0.10  && <0.11
+                     , cardano-binary
+                     , cardano-crypto-class
+                     , cardano-crypto-praos
+                     , cardano-data
+                     , cardano-ledger-core
+                     , cardano-protocol-tpraos < 0.1.1
+                     , cardano-prelude
+                     , cardano-slotting
+                     , cborg             >=0.2.2 && <0.3
+                     , containers        >=0.5   && <0.7
+                     , data-default-class
+                     , deepseq
+                     , measures
+                     , mtl               >=2.2   && <2.3
+                     , nothunks
+                     , orphans-deriving-via
+                     , serialise         >=0.2   && <0.3
+                     , strict-containers
+                     , text              >=1.2   && <1.3
+                     , transformers
+
+                       -- cardano-ledger-specs
+                     , cardano-ledger-alonzo
+                     , cardano-ledger-babbage
+                     , cardano-ledger-shelley
+                     , cardano-ledger-shelley-ma
+                     , small-steps
+
+                     , ouroboros-network < 0.4
+                     , ouroboros-consensus < 0.2
+                     , ouroboros-consensus-protocol < 0.2
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+


### PR DESCRIPTION
* `ouroboros-consensus-shelley-0.1.0.1` is compatible with
  `ouroboros-network < 0.4`.
* Relax upper bound of `cardano-data` in `cardano-ledger-shelley` to
  allow all minor versions `cardano-data-0.1.x`.
