### PR TITLE
Remove the caching from the CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,11 +42,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
-             
-      - uses: actions/cache@v3
-        with:
-          path: _cache
-          key: 1 # bump to refresh
 
       - name: Unpack keys
         env:


### PR DESCRIPTION
I don't trust it. Compare these two runs:
1. https://github.com/input-output-hk/cardano-haskell-packages/actions/runs/4532746158/jobs/7984714895
2. https://github.com/input-output-hk/cardano-haskell-packages/actions/runs/4516172089/jobs/7954255360

The second is on the parent commit of the first, the commit itself is a
no-op, and yet the derivations
they build are not the same! Doing the same locally, I get a) a
different derivation, but b) the same derivation for both.

I conclude that what the CI is doing is questionable, the cache seems
like the most likely source of pollution.

I suspect whatever is causing this was also responsible for the no-op PR
spending a lot of time building tons of stuff.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
