### PR TITLE
Add scripts for updating timestamps

### DIFF
--- a/scripts/update-timestamps-and-fixup.sh
+++ b/scripts/update-timestamps-and-fixup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Creates a fixup commit for the given revision that updates any 
+# timestamps introduced in that revision
+
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "$(which "$0")")
+
+REVISION=$1
+
+echo "Updating timestamps in commit $(git rev-parse $REVISION)" 
+
+$SCRIPT_DIR/update-timestamps-in-revision.sh $REVISION
+
+git add _sources
+
+if git diff --quiet --cached --exit-code; then
+  echo "No changes were made, nothing to commit"
+else
+  echo " Committing changes"
+  git commit --fixup=$REVISION
+fi

--- a/scripts/update-timestamps-in-revision.sh
+++ b/scripts/update-timestamps-in-revision.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Updates any timestamps which were introduced in the given revision
+
+# Don't set pipefail since the pipeline below can fail if there are
+# no changes to be made
+set -o errexit
+
+SCRIPT_DIR=$(dirname "$(which "$0")")
+
+REVISION=$1
+
+# 1. Print the diff, including only changed lines (no context) in _sources
+# 2. Filter for 'timestamp = <something>'
+# 3. Cut out just the timestamp
+TIMESTAMPS_IN_DIFF=$(git show $REVISION --patch --unified=0 -- _sources | grep -oP "timestamp = (.*)" | cut -f 3 -d ' ')
+
+echo "Found the following timestamps in the diff: $TIMESTAMPS_IN_DIFF"
+
+for OLD_TIMESTAMP in $TIMESTAMPS_IN_DIFF; do
+  NEW_TIMESTAMP=$($SCRIPT_DIR/current-timestamp.sh)
+  echo "Replacing $OLD_TIMESTAMP with $NEW_TIMESTAMP"
+  # Blindly replace the old timestamp with a fresh timestamp in every meta.toml. This assumes
+  # that the timestamp that we found in the diff was unique, and so this will only hit that
+  # file, which is pretty safe.
+  find _sources -type f -name "meta.toml" -exec sed -i s/$OLD_TIMESTAMP/$NEW_TIMESTAMP/g {} +
+done


### PR DESCRIPTION
I have a PR with multiple changes that now has old timestamps because
something else got merged. Writing these scripts seemed faster than
doing it by hand!

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
