### PR TITLE
Patch `servant-server`, `vector-algorithms`, `hedgehog`

### DIFF
--- a/_sources/hedgehog/1.2.0.0.0.0.1/meta.toml
+++ b/_sources/hedgehog/1.2.0.0.0.0.1/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2023-04-03T16:59:56Z
 github = { repo = "hedgehogqa/haskell-hedgehog", rev = "70cf9fd0719e2d0ace1093cbe75673d7b9b4cf65" }
 subdir = 'hedgehog'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-03T17:01:06Z

--- a/_sources/hedgehog/1.2.0.0.0.0.1/meta.toml
+++ b/_sources/hedgehog/1.2.0.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2023-04-03T16:59:56Z
+github = { repo = "hedgehogqa/haskell-hedgehog", rev = "70cf9fd0719e2d0ace1093cbe75673d7b9b4cf65" }
+subdir = 'hedgehog'
+force-version = true

--- a/_sources/hedgehog/1.2.0.0.0.0.1/revisions/1.cabal
+++ b/_sources/hedgehog/1.2.0.0.0.0.1/revisions/1.cabal
@@ -1,0 +1,121 @@
+cabal-version:      >=1.10
+name:               hedgehog
+version:            1.2.0.0.0.0.1
+license:            BSD3
+license-file:       LICENSE
+maintainer:         Jacob Stanley <jacob@stanley.io>
+author:             Jacob Stanley
+tested-with:
+    ghc ==8.0.2 ghc ==8.2.2 ghc ==8.4.4 ghc ==8.6.5 ghc ==8.8.3
+    ghc ==8.10.1 ghc ==9.2.1
+
+homepage:           https://hedgehog.qa
+bug-reports:        https://github.com/hedgehogqa/haskell-hedgehog/issues
+synopsis:           Release with confidence.
+description:
+    <http://hedgehog.qa/ Hedgehog> automatically generates a comprehensive array
+    of test cases, exercising your software in ways human testers would never
+    imagine.
+    .
+    Generate hundreds of test cases automatically, exposing even the
+    most insidious of corner cases. Failures are automatically simplified, giving
+    developers coherent, intelligible error messages.
+    .
+    To get started quickly, see the <https://github.com/hedgehogqa/haskell-hedgehog/tree/master/hedgehog-example examples>.
+
+category:           Testing
+build-type:         Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: git://github.com/hedgehogqa/haskell-hedgehog.git
+
+library
+    exposed-modules:
+        Hedgehog
+        Hedgehog.Gen
+        Hedgehog.Main
+        Hedgehog.Range
+        Hedgehog.Internal.Barbie
+        Hedgehog.Internal.Config
+        Hedgehog.Internal.Discovery
+        Hedgehog.Internal.Distributive
+        Hedgehog.Internal.Exception
+        Hedgehog.Internal.Gen
+        Hedgehog.Internal.HTraversable
+        Hedgehog.Internal.Opaque
+        Hedgehog.Internal.Prelude
+        Hedgehog.Internal.Property
+        Hedgehog.Internal.Queue
+        Hedgehog.Internal.Range
+        Hedgehog.Internal.Region
+        Hedgehog.Internal.Report
+        Hedgehog.Internal.Runner
+        Hedgehog.Internal.Seed
+        Hedgehog.Internal.Show
+        Hedgehog.Internal.Shrink
+        Hedgehog.Internal.Source
+        Hedgehog.Internal.State
+        Hedgehog.Internal.TH
+        Hedgehog.Internal.Tree
+        Hedgehog.Internal.Tripping
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base >=4.9 && <5,
+        ansi-terminal >=0.6 && <0.12,
+        async >=2.0 && <2.3,
+        barbies >=1.0 && <2.1,
+        bytestring >=0.10 && <0.12,
+        concurrent-output >=1.7 && <1.11,
+        containers >=0.4 && <0.7,
+        deepseq >=1.1.0.0 && <1.5,
+        directory >=1.2 && <1.4,
+        erf >=2.0 && <2.1,
+        exceptions >=0.7 && <0.11,
+        lifted-async >=0.7 && <0.11,
+        mmorph >=1.0 && <1.3,
+        monad-control >=1.0 && <1.1,
+        mtl >=2.1 && <2.4,
+        pretty-show >=1.6 && <1.11,
+        primitive >=0.6 && <0.9,
+        random >=1.1 && <1.3,
+        resourcet >=1.1 && <1.4,
+        stm >=2.4 && <2.6,
+        template-haskell >=2.10 && <2.20,
+        text >=1.1 && <2.1,
+        time >=1.4 && <1.13,
+        transformers >=0.5 && <0.7,
+        transformers-base >=0.4.5.1 && <0.5,
+        wl-pprint-annotated >=0.0 && <0.2
+
+test-suite test
+    type:             exitcode-stdio-1.0
+    main-is:          test.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Hedgehog.Applicative
+        Test.Hedgehog.Confidence
+        Test.Hedgehog.Filter
+        Test.Hedgehog.Maybe
+        Test.Hedgehog.Seed
+        Test.Hedgehog.Skip
+        Test.Hedgehog.Text
+        Test.Hedgehog.Zip
+
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded -O2
+    build-depends:
+        hedgehog,
+        base >=3 && <5,
+        containers >=0.4 && <0.7,
+        mmorph >=1.0 && <1.3,
+        mtl >=2.1 && <2.4,
+        pretty-show >=1.6 && <1.11,
+        text >=1.1 && <2.1,
+        transformers >=0.3 && <0.7

--- a/_sources/servant-server/0.19.2.0.0.0.0.1/meta.toml
+++ b/_sources/servant-server/0.19.2.0.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2023-04-03T17:04:10Z
+github = { repo = "haskell-servant/servant", rev = "58aa0d1c0c19f7b1c26ffc52bfd65c70934704c9" }
+subdir = 'servant-server'
+force-version = true

--- a/_sources/servant-server/0.19.2.0.0.0.0.1/meta.toml
+++ b/_sources/servant-server/0.19.2.0.0.0.0.1/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2023-04-03T17:04:10Z
 github = { repo = "haskell-servant/servant", rev = "58aa0d1c0c19f7b1c26ffc52bfd65c70934704c9" }
 subdir = 'servant-server'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-03T17:05:03Z

--- a/_sources/servant-server/0.19.2.0.0.0.0.1/revisions/1.cabal
+++ b/_sources/servant-server/0.19.2.0.0.0.0.1/revisions/1.cabal
@@ -1,0 +1,149 @@
+cabal-version:      2.2
+name:               servant-server
+version:            0.19.2.0.0.0.0.1
+license:            BSD-3-Clause
+license-file:       LICENSE
+copyright:
+    2014-2016 Zalora South East Asia Pte Ltd, 2016-2019 Servant Contributors
+
+maintainer:         haskell-servant-maintainers@googlegroups.com
+author:             Servant Contributors
+tested-with:        ghc ==8.6.5 || ==8.8.4 || ==8.10.2 || ==9.0.1
+homepage:           http://docs.servant.dev/
+bug-reports:        http://github.com/haskell-servant/servant/issues
+synopsis:
+    A family of combinators for defining webservices APIs and serving them
+
+description:
+    A family of combinators for defining webservices APIs and serving them
+    .
+    You can learn about the basics in the <http://docs.servant.dev/en/stable/tutorial/index.html tutorial>.
+    .
+    <https://github.com/haskell-servant/servant/blob/master/servant-server/example/greet.hs Here>
+    is a runnable example, with comments, that defines a dummy API and implements
+    a webserver that serves this API, using this package.
+    .
+    <https://github.com/haskell-servant/servant/blob/master/servant-server/CHANGELOG.md CHANGELOG>
+
+category:           Servant, Web
+build-type:         Simple
+extra-source-files:
+    CHANGELOG.md
+    README.md
+
+source-repository head
+    type:     git
+    location: http://github.com/haskell-servant/servant.git
+
+library
+    exposed-modules:
+        Servant
+        Servant.Server
+        Servant.Server.Experimental.Auth
+        Servant.Server.Generic
+        Servant.Server.Internal
+        Servant.Server.Internal.BasicAuth
+        Servant.Server.Internal.Context
+        Servant.Server.Internal.Delayed
+        Servant.Server.Internal.DelayedIO
+        Servant.Server.Internal.ErrorFormatter
+        Servant.Server.Internal.Handler
+        Servant.Server.Internal.RouteResult
+        Servant.Server.Internal.Router
+        Servant.Server.Internal.RoutingApplication
+        Servant.Server.Internal.ServerError
+        Servant.Server.StaticFiles
+        Servant.Server.UVerb
+        Servant.Utils.StaticFiles
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:      -Wall -Wno-redundant-constraints
+    build-depends:
+        base >=4.9 && <4.18,
+        bytestring >=0.10.8.1 && <0.12,
+        constraints >=0.2 && <0.14,
+        containers >=0.5.7.1 && <0.7,
+        mtl >=2.2.2 && <2.3,
+        text >=1.2.3.0 && <2.1,
+        transformers >=0.5.2.0 && <0.6,
+        filepath >=1.4.1.1 && <1.5,
+        servant >=0.19 && <0.20,
+        http-api-data >=0.4.1 && <0.5.1,
+        base-compat >=0.10.5 && <0.13,
+        base64-bytestring >=1.0.0.1 && <1.3,
+        exceptions >=0.10.0 && <0.11,
+        http-media >=0.7.1.3 && <0.9,
+        http-types >=0.12.2 && <0.13,
+        network-uri >=2.6.1.0 && <2.8,
+        monad-control >=1.0.2.3 && <1.1,
+        network >=2.8 && <3.2,
+        sop-core >=0.4.0.0 && <0.6,
+        string-conversions >=0.4.0.1 && <0.5,
+        resourcet >=1.2.2 && <1.4,
+        tagged >=0.8.6 && <0.9,
+        transformers-base >=0.4.5.2 && <0.5,
+        wai >=3.2.1.2 && <3.3,
+        wai-app-static >=3.1.6.2 && <3.2,
+        word8 >=0.1.3 && <0.2
+
+executable greet
+    main-is:          greet.hs
+    hs-source-dirs:   example
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base,
+        base-compat,
+        servant,
+        servant-server,
+        wai,
+        text,
+        aeson >=1.4.1.0 && <3,
+        warp >=3.2.25 && <3.4
+
+test-suite spec
+    type:               exitcode-stdio-1.0
+    main-is:            Spec.hs
+    build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.10
+    hs-source-dirs:     test
+    other-modules:
+        Servant.ArbitraryMonadServerSpec
+        Servant.Server.ErrorSpec
+        Servant.Server.Internal.ContextSpec
+        Servant.Server.Internal.RoutingApplicationSpec
+        Servant.Server.RouterSpec
+        Servant.Server.StaticFilesSpec
+        Servant.Server.StreamingSpec
+        Servant.Server.UsingContextSpec
+        Servant.Server.UsingContextSpec.TestCombinators
+        Servant.HoistSpec
+        Servant.ServerSpec
+
+    default-language:   Haskell2010
+    ghc-options:        -Wall
+    build-depends:
+        base,
+        base-compat,
+        base64-bytestring,
+        bytestring,
+        http-types,
+        mtl,
+        resourcet,
+        safe,
+        servant,
+        servant-server,
+        sop-core,
+        string-conversions,
+        text,
+        transformers,
+        transformers-compat,
+        wai,
+        aeson >=1.4.1.0 && <3,
+        directory >=1.3.0.0 && <1.4,
+        hspec >=2.6.0 && <2.10,
+        hspec-wai >=0.10.1 && <0.12,
+        QuickCheck >=2.12.6.1 && <2.15,
+        should-not-typecheck >=2.1.0 && <2.2,
+        temporary >=1.3 && <1.4,
+        wai-extra >=3.0.24.3 && <3.2

--- a/_sources/vector-algorithms/0.9.0.1.0.0.0.0.1/meta.toml
+++ b/_sources/vector-algorithms/0.9.0.1.0.0.0.0.1/meta.toml
@@ -1,0 +1,7 @@
+timestamp = 2023-04-03T17:08:55Z
+github = { repo = "erikd/vector-algorithms", rev = "e3fc242ac75d928ca613be9702ff2946011ef7d4" }
+force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-03T17:09:42Z

--- a/_sources/vector-algorithms/0.9.0.1.0.0.0.0.1/revisions/1.cabal
+++ b/_sources/vector-algorithms/0.9.0.1.0.0.0.0.1/revisions/1.cabal
@@ -1,0 +1,142 @@
+cabal-version:      >=1.10
+name:               vector-algorithms
+version:            0.9.0.1.0.0.0.0.1
+license:            BSD3
+license-file:       LICENSE
+copyright:
+    (c) 2008,2009,2010,2011,2012,2013,2014,2015 Dan Doel
+    (c) 2015 Tim Baumann
+
+maintainer:
+    Dan Doel <dan.doel@gmail.com>
+    Erik de Castro Lopo <erikd@mega-nerd.com>
+
+author:             Dan Doel
+homepage:           https://github.com/erikd/vector-algorithms/
+synopsis:           Efficient algorithms for vector arrays
+description:
+    Efficient algorithms for sorting vector arrays. At some stage
+    other vector algorithms may be added.
+
+category:           Data
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/erikd/vector-algorithms/
+
+flag boundschecks
+    description: Enable bounds checking
+
+flag unsafechecks
+    description:
+        Enable bounds checking in unsafe operations at the cost of a
+        significant performance penalty.
+
+    default:     False
+
+flag internalchecks
+    description:
+        Enable internal consistency checks at the cost of a
+        significant performance penalty.
+
+    default:     False
+
+flag bench
+    description:
+        Build a benchmarking program to test vector-algorithms
+        performance
+
+flag properties
+    description: Enable the quickcheck tests
+
+flag llvm
+    description: Build using llvm
+    default:     False
+
+library
+    exposed-modules:
+        Data.Vector.Algorithms
+        Data.Vector.Algorithms.Optimal
+        Data.Vector.Algorithms.Insertion
+        Data.Vector.Algorithms.Intro
+        Data.Vector.Algorithms.Merge
+        Data.Vector.Algorithms.Radix
+        Data.Vector.Algorithms.Search
+        Data.Vector.Algorithms.Heap
+        Data.Vector.Algorithms.AmericanFlag
+        Data.Vector.Algorithms.Tim
+
+    hs-source-dirs:   src
+    other-modules:    Data.Vector.Algorithms.Common
+    default-language: Haskell2010
+    include-dirs:     include
+    install-includes: vector.h
+    ghc-options:      -funbox-strict-fields
+    build-depends:
+        base >=4.5 && <5,
+        bitvec >=1.0 && <1.2,
+        vector >=0.6 && <0.14,
+        primitive >=0.3 && <0.9,
+        bytestring >=0.9 && <1.0
+
+    if !impl(ghc >=7.8)
+        build-depends: tagged >=0.4 && <0.9
+
+    if flag(llvm)
+        ghc-options: -fllvm
+
+    if flag(boundschecks)
+        cpp-options: -DVECTOR_BOUNDS_CHECKS
+
+    if flag(unsafechecks)
+        cpp-options: -DVECTOR_UNSAFE_CHECKS
+
+    if flag(internalchecks)
+        cpp-options: -DVECTOR_INTERNAL_CHECKS
+
+test-suite properties
+    type:             exitcode-stdio-1.0
+    main-is:          Tests.hs
+    hs-source-dirs:   tests/properties
+    other-modules:
+        Optimal
+        Properties
+        Util
+
+    default-language: Haskell2010
+
+    if !flag(properties)
+        buildable: False
+
+    else
+        build-depends:
+            base,
+            bytestring,
+            containers,
+            QuickCheck >2.9 && <2.15,
+            vector,
+            vector-algorithms
+
+    if flag(llvm)
+        ghc-options: -fllvm
+
+benchmark simple-bench
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   bench/simple
+    other-modules:    Blocks
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base,
+        mwc-random,
+        vector,
+        vector-algorithms
+
+    if !flag(bench)
+        buildable: False
+
+    if flag(llvm)
+        ghc-options: -fllvm


### PR DESCRIPTION
Patches for three hackage packages to allow newer for `resourcet` and `primitive`.