### PR TITLE
Rework builder to work with new haskell.nix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,11 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: accept-flake-config = true
 
+      - name: Setup nixbuild.net
+        uses: nixbuild/nixbuild-action@v16
+        with:
+          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
+
       - name: Run checks
         run: nix develop -c ./scripts/check.sh
 
@@ -37,6 +42,11 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: accept-flake-config = true
+
+      - name: Setup nixbuild.net
+        uses: nixbuild/nixbuild-action@v16
+        with:
+          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
 
       - name: Checkout main 
         uses: actions/checkout@v3

--- a/flake.lock
+++ b/flake.lock
@@ -208,15 +208,16 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -342,6 +343,7 @@
         "hackage": [
           "hackage-nix"
         ],
+        "hls-1.10": "hls-1.10",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -360,16 +362,33 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1678849774,
-        "narHash": "sha256-xYXstGlytKVcqFaYiDbu9onpWEo4idgVyMD811Hla+U=",
+        "lastModified": 1681292435,
+        "narHash": "sha256-Mdo8DDZLcoD1nrzTp/umD9OefKi26Vu9gszuGEKolr4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6ffd8778d5e423aaef84a3766e55c19906a82c7b",
+        "rev": "e00f3ee12a4ab8a348d5580b5477eb4619a0fe32",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -854,11 +873,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1678839001,
-        "narHash": "sha256-i4Z+YDYYx7y3sdHcIc7sq5JxIJiGO1hB91eprZ7R894=",
+        "lastModified": 1681085376,
+        "narHash": "sha256-kSg4N5g9Jj8u+G7HdMZR5IIvm40s9EBmkD0pMDTJTLc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "1318f064092c1f17df9c9c2b280bf72531e4642f",
+        "rev": "2f9242acfd8fbbc4bbdc5e5504ac8e5b36839b7f",
         "type": "github"
       },
       "original": {

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -58,5 +58,6 @@ let
       # actually run tests: CHaP will not check that your tests pass (neither
       # does Hackage).
       constituents = components;
-    }; 
+      # pass through the plan for debugging purposes
+    } // { passthru = { inherit (project) plan-nix; }; }; 
 in build-chap-package

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -30,17 +30,13 @@ let
         name = package-id;
         src = ./empty;
 
-        inputMap = {
-          "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP;
-        };
-
         # Note that we do not set tests or benchmarks to True, so we won't
         # build them by default. This is the same as what happens on Hackage,
         # for example, and they can't be depended on by downstream packages
         # anyway.
         cabalProject = ''
           repository cardano-haskell-packages
-            url: https://input-output-hk.github.io/cardano-haskell-packages
+            url: file:${CHaP}
             secure: True
 
           extra-packages: ${package-id}


### PR DESCRIPTION
Now haskell.nix fetches the sdists from the actual repository URL, not the flake input. But for new packages they won't be _in_ the remote version of `cardano-haskell-packages`, so it will fail. Instead we use the flake input as the repo directly.

Contains a fake package publish just to test the CI. Do not merge with that in.

Do not merge until https://github.com/input-output-hk/haskell.nix/pull/1910 is merged also.
