### PR TITLE
Add a revision for `libsystemd-journal` to allow newer `unix-bytestring`

### DIFF
--- a/_sources/libsystemd-journal/1.4.5.0.0.0.0.1/meta.toml
+++ b/_sources/libsystemd-journal/1.4.5.0.0.0.0.1/meta.toml
@@ -5,3 +5,7 @@ force-version = true
 [[revisions]]
 number = 1
 timestamp = 2023-03-31T11:59:45Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-04-11T20:31:44Z

--- a/_sources/libsystemd-journal/1.4.5.0.0.0.0.1/revisions/2.cabal
+++ b/_sources/libsystemd-journal/1.4.5.0.0.0.0.1/revisions/2.cabal
@@ -1,0 +1,34 @@
+cabal-version:      >=1.10
+name:               libsystemd-journal
+version:            1.4.5.0.0.0.0.1
+license:            BSD3
+license-file:       LICENSE
+copyright:          Oliver Charles (c) 2014
+maintainer:         ollie@ocharles.org.uk
+author:             Oliver Charles
+homepage:           http://github.com/ocharles/libsystemd-journal
+synopsis:           Haskell bindings to libsystemd-journal
+category:           System
+build-type:         Simple
+extra-source-files: Changelog.md
+
+library
+    exposed-modules:   Systemd.Journal
+    pkgconfig-depends: libsystemd >=209
+    hs-source-dirs:    src
+    default-language:  Haskell2010
+    build-depends:
+        base >=4.6 && <5,
+        bytestring >=0.9.1,
+        pipes >=4.0,
+        pipes-safe >=2.0,
+        text >=0.1 && <2.1,
+        transformers >=0.3,
+        unix-bytestring >=0.3.2 && <0.5,
+        vector >=0.4 && <0.14,
+        uuid,
+        unordered-containers >=0.1 && <0.3,
+        hashable >=1.1.2.5,
+        hsyslog,
+        uniplate >=1.6,
+        semigroups >=0.1 && <0.21


### PR DESCRIPTION
I was able to successfully build `cardano-node` with newest `unix-bytestring-0.4`. Only bounds that are updated in this revision are:
```diff
-         unix-bytestring >=0.3.2 && <0.4,
+         unix-bytestring >=0.3.2 && <0.5,
```