### PR TITLE
Add a catch-all CODEOWNERS rule for trustees

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
+# Anything that isn't explicitly owned by a team 
+# needs approval from the admins
+* @input-output-hk/cardano-haskell-packages-trustees
+
 # cardano-node
 _sources/cardano-api             @input-output-hk/release
 _sources/cardano-cli             @input-output-hk/release
@@ -6,9 +10,7 @@ _sources/cardano-node            @input-output-hk/release
 _sources/cardano-submit-api      @input-output-hk/release
 _sources/cardano-testnet         @input-output-hk/release
 
-
 # cardano-ledger
-
 _sources/byron-spec-chain        @input-output-hk/cardano-ledger
 _sources/byron-spec-ledger       @input-output-hk/cardano-ledger
 _sources/cardano-crypto-test     @input-output-hk/cardano-ledger
@@ -19,6 +21,7 @@ _sources/cardano-ledger-pretty   @input-output-hk/cardano-ledger
 _sources/cardano-ledger-test     @input-output-hk/cardano-ledger
 _sources/cardano-protocol-tpraos @input-output-hk/cardano-ledger
 _sources/ledger-state            @input-output-hk/cardano-ledger
+_sources/moo                     @input-output-hk/cardano-ledger
 _sources/non-integral            @input-output-hk/cardano-ledger
 _sources/plutus-preprocessor     @input-output-hk/cardano-ledger
 _sources/set-algebra             @input-output-hk/cardano-ledger
@@ -89,6 +92,10 @@ _sources/plutus-tx-plugin           @input-output-hk/plutus-core
 _sources/prettyprinter-configurable @input-output-hk/plutus-core
 _sources/word-array                 @input-output-hk/plutus-core
 
+_sources/flat     @input-output-hk/plutus-core
+_sources/inline-r @input-output-hk/plutus-core
+_sources/int-cast @input-output-hk/plutus-core
+
 # plutus-apps
 _sources/quickcheck-contractmodel @input-output-hk/plutus-tools
 
@@ -112,13 +119,6 @@ _sources/trace-forward                  @input-output-hk/performance-tracing
 _sources/trace-resources                @input-output-hk/performance-tracing
 _sources/tracer-transformers            @input-output-hk/performance-tracing
 _sources/tx-generator                   @input-output-hk/performance-tracing
-
-# Patched packages
-
-_sources/flat     @input-output-hk/plutus-core
-_sources/inline-r @input-output-hk/plutus-core
-_sources/int-cast @input-output-hk/plutus-core
-_sources/moo      @input-output-hk/cardano-ledger
 
 # Marlowe
 _sources/marlowe           @input-output-hk/marlowe

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ contains the metadata specifying all the package versions. The package repositor
 
 ## Help!
 
-If you have trouble, open an issue, or contact the maintainers:
-
-- Andrea Bedini (andrea.bedini@iohk.io)
-- Michael Peyton Jones (michael.peyton-jones@iohk.io)
+If you have trouble, open an issue, or contact the trustees: @input-output-hk/cardano-haskell-packages-trustees
 
 ## Background 
 


### PR DESCRIPTION
At the moment we're using CODEOWNERS to manage access control. That
works for what it covers, but some stuff _isn't_ covered.

That means that anyone who is part of the teams with write access can,
e.g. push a new package, including patched Hackage packages; add new
package versions of anything that isn't owned; alter the CI; etc.

There's a fairly simple solution: just add a catch all rule for the CHaP
"trustee" team (a new team I just made so that it can be distinct from
the team which has admin on the repo).  This means that everyting will
get reviewed by _someone_.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
