### PR TITLE
Cardano base packages with ghc 9.6 support

### DIFF
--- a/_sources/cardano-binary-test/1.4.0.2/meta.toml
+++ b/_sources/cardano-binary-test/1.4.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-26T21:43:05Z
+github = { repo = "input-output-hk/cardano-base", rev = "ff892bfd88f030144b2ec60e1ef372476069c5f1" }
+subdir = 'cardano-binary/test'

--- a/_sources/cardano-binary/1.7.0.1/meta.toml
+++ b/_sources/cardano-binary/1.7.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-26T21:43:05Z
+github = { repo = "input-output-hk/cardano-base", rev = "ff892bfd88f030144b2ec60e1ef372476069c5f1" }
+subdir = 'cardano-binary'

--- a/_sources/cardano-crypto-praos/2.1.1.2/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-26T21:43:05Z
+github = { repo = "input-output-hk/cardano-base", rev = "ff892bfd88f030144b2ec60e1ef372476069c5f1" }
+subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-slotting/0.1.1.1/meta.toml
+++ b/_sources/cardano-slotting/0.1.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-26T21:43:05Z
+github = { repo = "input-output-hk/cardano-base", rev = "ff892bfd88f030144b2ec60e1ef372476069c5f1" }
+subdir = 'cardano-slotting'


### PR DESCRIPTION
Rest of the packages from cardano-base with ghc-9.6 support. `cardano-crypto-class` and `cardano-crypto-tests` have already been released in #229 