### PR TITLE
Revision #1 for set-algebra to use cardano-data <1.1

### DIFF
--- a/_sources/set-algebra/0.1.0.0/meta.toml
+++ b/_sources/set-algebra/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T10:23:01Z

--- a/_sources/set-algebra/0.1.0.0/revisions/1.cabal
+++ b/_sources/set-algebra/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,63 @@
+cabal-version: 2.2
+
+name:                set-algebra
+version:             0.1.0.0
+synopsis:            Set Algebra
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:  CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/set-algebra
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.Iterate.BaseTypes
+                     , Control.Iterate.Collect
+                     , Control.Iterate.Exp
+                     , Control.Iterate.SetAlgebra
+                     , Control.SetAlgebra
+
+  build-depends:       ansi-wl-pprint
+                     , base >=4.11 && <5
+                     , cardano-data <1.1
+                     , containers
+  hs-source-dirs:      src
+
+test-suite tests
+  import:             project-config
+
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Test.Control.Iterate.SetAlgebra
+                     , Test.Control.Iterate.RelationReference
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       base
+                     , containers
+                     , set-algebra
+                     , tasty
+                     , tasty-hunit
+                     , tasty-quickcheck
+                     , cardano-data
+  ghc-options:        -threaded

--- a/_sources/set-algebra/0.1.1.1/meta.toml
+++ b/_sources/set-algebra/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T11:20:06Z

--- a/_sources/set-algebra/0.1.1.1/revisions/1.cabal
+++ b/_sources/set-algebra/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,63 @@
+cabal-version: 2.2
+
+name:                set-algebra
+version:             0.1.1.1
+synopsis:            Set Algebra
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:  CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/set-algebra
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.Iterate.BaseTypes
+                     , Control.Iterate.Collect
+                     , Control.Iterate.Exp
+                     , Control.Iterate.SetAlgebra
+                     , Control.SetAlgebra
+
+  build-depends:       ansi-wl-pprint
+                     , base >=4.11 && <5
+                     , cardano-data <1.1
+                     , containers
+  hs-source-dirs:      src
+
+test-suite tests
+  import:             project-config
+
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Test.Control.Iterate.SetAlgebra
+                     , Test.Control.Iterate.RelationReference
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       base
+                     , containers
+                     , set-algebra
+                     , tasty
+                     , tasty-hunit
+                     , tasty-quickcheck
+                     , cardano-data
+  ghc-options:        -threaded

--- a/_sources/set-algebra/0.1.1.2/meta.toml
+++ b/_sources/set-algebra/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T11:20:41Z

--- a/_sources/set-algebra/0.1.1.2/revisions/1.cabal
+++ b/_sources/set-algebra/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,63 @@
+cabal-version: 2.2
+
+name:                set-algebra
+version:             0.1.1.2
+synopsis:            Set Algebra
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:  CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/set-algebra
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.Iterate.BaseTypes
+                     , Control.Iterate.Collect
+                     , Control.Iterate.Exp
+                     , Control.Iterate.SetAlgebra
+                     , Control.SetAlgebra
+
+  build-depends:       ansi-wl-pprint
+                     , base >=4.11 && <5
+                     , cardano-data <1.1
+                     , containers
+  hs-source-dirs:      src
+
+test-suite tests
+  import:             project-config
+
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Test.Control.Iterate.SetAlgebra
+                     , Test.Control.Iterate.RelationReference
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       base
+                     , containers
+                     , set-algebra
+                     , tasty
+                     , tasty-hunit
+                     , tasty-quickcheck
+                     , cardano-data
+  ghc-options:        -threaded

--- a/_sources/set-algebra/1.0.0.0/meta.toml
+++ b/_sources/set-algebra/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T11:21:11Z

--- a/_sources/set-algebra/1.0.0.0/revisions/1.cabal
+++ b/_sources/set-algebra/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,59 @@
+cabal-version:      3.0
+name:               set-algebra
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:           Set Algebra
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/set-algebra
+
+library
+    exposed-modules:
+        Control.Iterate.BaseTypes
+        Control.Iterate.Collect
+        Control.Iterate.Exp
+        Control.Iterate.SetAlgebra
+        Control.SetAlgebra
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        ansi-wl-pprint,
+        cardano-data <1.1,
+        containers
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Control.Iterate.SetAlgebra
+        Test.Control.Iterate.RelationReference
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        set-algebra,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        cardano-data


### PR DESCRIPTION
A previously exposed module and some instances were removed from `cardano-data >=1.1` in [cardano-ledger/#3371](https://github.com/input-output-hk/cardano-ledger/pull/3371).

This PR adds revisions to all previously released versions of `set-algebra` to restrict its dependency on `cardano-data` to be `<1.1`.
