### PR TITLE
Add a revision for `fs-sim` and `fs-api`

### DIFF
--- a/_sources/fs-api/0.1.0.1/meta.toml
+++ b/_sources/fs-api/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-25T08:35:30Z
 github = { repo = "input-output-hk/fs-sim", rev = "20e9c5953a6efeb77f496be25598e4de5b9440ee" }
 subdir = 'fs-api'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T08:53:31Z

--- a/_sources/fs-api/0.1.0.1/revisions/1.cabal
+++ b/_sources/fs-api/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,74 @@
+cabal-version:   3.0
+name:            fs-api
+version:         0.1.0.1
+synopsis:        API for file systems
+description:     API for file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        System
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10.7 || ==9.2.5
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/fs-sim
+  subdir:   fs-api
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:   src
+
+  if os(windows)
+    hs-source-dirs: src-win32
+
+  else
+    hs-source-dirs: src-unix
+
+  exposed-modules:
+    System.FS.API
+    System.FS.API.Types
+    System.FS.CRC
+    System.FS.Handle
+    System.FS.IO
+    System.IO.FS
+    Util.CallStack
+    Util.Condense
+
+  default-language: Haskell2010
+  build-depends:
+    , base        >=4.14 && <4.17
+    , bytestring  >=0.10 && <0.12
+    , containers  >=0.5  && <0.7
+    , deepseq
+    , digest
+    , directory   >=1.3  && <1.4
+    , filepath    >=1.4  && <1.5
+    , io-classes  >=0.3  && <1.2
+    , text        >=1.2  && <1.3
+
+  if os(windows)
+    build-depends: Win32 >=2.6.1.0
+
+  else
+    build-depends:
+      , unix
+      , unix-bytestring  >=0.4.0
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts

--- a/_sources/fs-sim/0.1.0.1/meta.toml
+++ b/_sources/fs-sim/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-25T08:35:30Z
 github = { repo = "input-output-hk/fs-sim", rev = "20e9c5953a6efeb77f496be25598e4de5b9440ee" }
 subdir = 'fs-sim'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T08:53:31Z

--- a/_sources/fs-sim/0.1.0.1/revisions/1.cabal
+++ b/_sources/fs-sim/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,93 @@
+cabal-version:   3.0
+name:            fs-sim
+version:         0.1.0.1
+synopsis:        Simulated file systems
+description:     Simulated file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Testing
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10.7 || ==9.2.5
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/fs-sim
+  subdir:   fs-sim
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:   src
+  exposed-modules:
+    System.FS.Sim.Error
+    System.FS.Sim.FsTree
+    System.FS.Sim.MockFS
+    System.FS.Sim.Pure
+    System.FS.Sim.STM
+
+  default-language: Haskell2010
+  build-depends:
+    , base               >=4.14 && <4.17
+    , base16-bytestring
+    , bytestring         >=0.10 && <0.12
+    , containers         >=0.5  && <0.7
+    , fs-api             ^>=0.1
+    , io-classes         >=0.3  && <1.2
+    , mtl
+    , QuickCheck
+    , strict-stm         >=0.3  && <1.2
+    , text               >=1.2  && <1.3
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+test-suite fs-sim-test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  other-modules:
+    Test.System.FS.Sim.FsTree
+    Test.System.FS.StateMachine
+    Test.Util.RefEnv
+
+  default-language: Haskell2010
+  build-depends:
+    , base                      >=4.14  && <4.17
+    , bifunctors
+    , bytestring
+    , containers
+    , fs-api
+    , fs-sim
+    , generics-sop
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  >=0.7.2
+    , random
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , temporary
+    , text
+    , tree-diff
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -fno-ignore-asserts


### PR DESCRIPTION
... that relaxes the bounds to use `io-classes`,  and `strict-stm` to include version `1.1` of these packages.

