### PR TITLE
coot/ouroboros network 0.6.0.0

### DIFF
--- a/_sources/cardano-ping/0.1.0.0/meta.toml
+++ b/_sources/cardano-ping/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-03-21T09:28:25Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "d9a002347843e88bc725b185d00ba535edb72e29" }
 subdir = 'cardano-ping'
+
+[[revisions]]
+number = 1
+timestamp = 2023-04-28T17:50:23Z

--- a/_sources/cardano-ping/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-ping/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,53 @@
+cabal-version: 3.0
+
+name:                   cardano-ping
+version:                0.1.0.0
+synopsis:               Utility for pinging cardano nodes
+description:            Utility for pinging cardano nodes.
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019-2023 Input Output Global Inc (IOG)
+author:                 Karl Knutsson
+maintainer:             karl.knutsson-ext@cardanofoundation.org marcin.szamotulski@iohk.io
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+flag asserts
+  description:        Enable assertions
+  manual:             False
+  default:            False
+
+library
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Network.Ping
+  build-depends:        base                          >=4.14     && <4.17,
+                        aeson                         >=2.1.1.0  && <3,
+                        cborg                         >=0.2.8    && <0.3,
+                        bytestring                    >=0.10     && <0.12,
+                        contra-tracer                 >=0.1      && <0.2,
+                        io-classes                    >=0.3      && <0.4,
+                        network-mux                   >=0.3      && <0.5,
+                        strict-stm                    >=0.2      && <0.3,
+                        tdigest                       >=0.2.1.1  && <0.3,
+                        text                          >=1.2.4    && <2.1,
+
+                        -- The Windows version of network-3.1.2 is missing
+                        -- functions, see
+                        -- https://github.com/haskell/network/issues/484
+                        network                       >= 3.1.2.2  && < 3.2,
+
+  if flag(asserts)
+     ghc-options:       -fno-ignore-asserts
+
+  default-language:     Haskell2010
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Widentities
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages

--- a/_sources/monoidal-synchronisation/0.1.0.3/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'monoidal-synchronisation'

--- a/_sources/network-mux/0.4.0.0/meta.toml
+++ b/_sources/network-mux/0.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'network-mux'

--- a/_sources/ntp-client/0.0.1.1/meta.toml
+++ b/_sources/ntp-client/0.0.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ntp-client'

--- a/_sources/ouroboros-network-api/0.3.0.0/meta.toml
+++ b/_sources/ouroboros-network-api/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network-api'

--- a/_sources/ouroboros-network-framework/0.5.0.0/meta.toml
+++ b/_sources/ouroboros-network-framework/0.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-mock/0.1.0.1/meta.toml
+++ b/_sources/ouroboros-network-mock/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network-mock'

--- a/_sources/ouroboros-network-protocols/0.5.0.0/meta.toml
+++ b/_sources/ouroboros-network-protocols/0.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network-protocols'

--- a/_sources/ouroboros-network-testing/0.3.0.0/meta.toml
+++ b/_sources/ouroboros-network-testing/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network-testing'

--- a/_sources/ouroboros-network/0.6.0.0/meta.toml
+++ b/_sources/ouroboros-network/0.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-04-28T17:49:47Z
+github = { repo = "input-output-hk/ouroboros-network", rev = "b9f3907c508829b1751c3fb1d811a139d5efc826" }
+subdir = 'ouroboros-network'

--- a/flake.lock
+++ b/flake.lock
@@ -317,11 +317,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1681950405,
-        "narHash": "sha256-JQJz2rGneoPb+uNLBqi8SgKahyDnRd+gxBySLUjxwYw=",
+        "lastModified": 1682641452,
+        "narHash": "sha256-hUBB6B7A6UWiYYHtkeu+R+Xwvqd06chBZpwskx7WG28=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0a68428cdf1744e891ceaa735c31d3f82ff59745",
+        "rev": "62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Added ouroboros-network-0.6.0.0
- Added ouroboros-network-framework-0.5.0.0
- Added ntp-client-0.0.1.1
- Added monoidal-synchronisation-0.1.0.3
- Added network-mux-0.4.0.0
- Added ouroboros-network-api-0.3.0.0
- Added ouroboros-network-mock-0.1.0.1
- Added ouroboros-network-protocols-0.5.0.0
- Added ouroboros-network-testing-0.3.0.0
- cardano-ping: relax network-mux version bound
