### PR TITLE
Prevent README.md and CODE-OF-CONDUCT.md to trigger CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+    # do not run the workflow if only markdown files
+    # in the root folder were changed.
+    paths:
+      - "!*.md"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Maybe the better option is:

```
paths:
  # trigger if the workflow changed
  - ".github/workflows/**"
  # trigger if the flake changed
  - "flake.*"
  # trigger if nix, scripts, or _sources changed
  - "nix/**"
  - "scripts/**"
  - "_sources/**"
```

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
