### PR TITLE
Added optparse-applicative-fork-0.16.2.0

### DIFF
--- a/_sources/optparse-applicative-fork/0.16.2.0/meta.toml
+++ b/_sources/optparse-applicative-fork/0.16.2.0/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2023-05-05T06:06:26Z
+github = { repo = "input-output-hk/optparse-applicative", rev = "f3e0bc1b44b93866824c284565480a391d1f6c5f" }


### PR DESCRIPTION
From https://github.com/input-output-hk/optparse-applicative at f3e0bc1b44b93866824c284565480a391d1f6c5f

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
