### PR TITLE
Update typed-protocols versions (ghc-9.6)

### DIFF
--- a/_sources/typed-protocols-cborg/0.1.0.3/meta.toml
+++ b/_sources/typed-protocols-cborg/0.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-08T21:39:57Z
+github = { repo = "input-output-hk/typed-protocols", rev = "72348fa99253f3511eec21d9ecdb0b0a47af4468" }
+subdir = 'typed-protocols-cborg'

--- a/_sources/typed-protocols-examples/0.2.0.1/meta.toml
+++ b/_sources/typed-protocols-examples/0.2.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-08T21:39:57Z
+github = { repo = "input-output-hk/typed-protocols", rev = "72348fa99253f3511eec21d9ecdb0b0a47af4468" }
+subdir = 'typed-protocols-examples'

--- a/_sources/typed-protocols/0.1.0.5/meta.toml
+++ b/_sources/typed-protocols/0.1.0.5/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-08T21:39:57Z
+github = { repo = "input-output-hk/typed-protocols", rev = "72348fa99253f3511eec21d9ecdb0b0a47af4468" }
+subdir = 'typed-protocols'


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
