### PR TITLE
Release 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ $ nix build .#project.plan-nix.json \
 	--override-input CHaP path:/home/user/cardano-haskell-packages/_repo
 ```
 
-This is useful if you jsut want to see whether cabal is able to successfully
+This is useful if you just want to see whether cabal is able to successfully
 resolve dependencies and see what versions it picked.
 
 ## Making changes 

--- a/_sources/cardano-api/8.0.0/meta.toml
+++ b/_sources/cardano-api/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'cardano-api'

--- a/_sources/cardano-cli/8.0.0/meta.toml
+++ b/_sources/cardano-cli/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'cardano-cli'

--- a/_sources/cardano-git-rev/0.1.0.0/meta.toml
+++ b/_sources/cardano-git-rev/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-19T09:29:51Z
 github = { repo = "input-output-hk/cardano-node", rev = "950c4e222086fed5ca53564e642434ce9307b0b9" }
 subdir = 'cardano-git-rev'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-09T18:40:49Z

--- a/_sources/cardano-git-rev/0.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-git-rev/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,44 @@
+cabal-version: 3.0
+
+name:                   cardano-git-rev
+version:                0.1.0.0
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     README.md
+
+flag systemd
+  description: Enable systemd support
+  default:     True
+  manual:      False
+
+common base                         { build-depends: base                             >= 4.14       && < 4.17     }
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               base, project-config
+
+  hs-source-dirs:       src
+
+  exposed-modules:      Cardano.Git.Rev
+                        Cardano.Git.RevFromGit
+
+  build-depends:        cardano-prelude
+                      , file-embed
+                      , process
+                      , template-haskell
+                      , text

--- a/_sources/cardano-git-rev/0.1.1.0/meta.toml
+++ b/_sources/cardano-git-rev/0.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T19:02:47Z
+github = { repo = "input-output-hk/cardano-node", rev = "88ef1b2124e097c87f9ded61b2da6f3afbfad2d4" }
+subdir = 'cardano-git-rev'

--- a/_sources/cardano-node-chairman/8.0.0/meta.toml
+++ b/_sources/cardano-node-chairman/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'cardano-node-chairman'

--- a/_sources/cardano-node/8.0.0/meta.toml
+++ b/_sources/cardano-node/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'cardano-node'

--- a/_sources/cardano-testnet/8.0.0/meta.toml
+++ b/_sources/cardano-testnet/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'cardano-testnet'

--- a/_sources/cardano-topology/8.0.0/meta.toml
+++ b/_sources/cardano-topology/8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T17:00:09Z
+github = { repo = "input-output-hk/cardano-node", rev = "69a117b7be3db0f4ce6d9fc5cd4c16a2a409dcb8" }
+subdir = 'bench/cardano-topology'

--- a/_sources/ekg-forward/0.1.0/meta.toml
+++ b/_sources/ekg-forward/0.1.0/meta.toml
@@ -1,2 +1,6 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/ekg-forward", rev = "297cd9db5074339a2fb2e5ae7d0780debb670c63" }
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-09T18:20:13Z

--- a/_sources/ekg-forward/0.1.0/revisions/1.cabal
+++ b/_sources/ekg-forward/0.1.0/revisions/1.cabal
@@ -1,0 +1,128 @@
+cabal-version:       2.4
+name:                ekg-forward
+version:             0.1.0
+synopsis:            See README for more info
+description:         See README for more info
+homepage:            https://github.com/input-output-hk/ekg-forward
+bug-reports:         https://github.com/input-output-hk/ekg-forward/issues
+license:             Apache-2.0
+license-file:        LICENSE
+copyright:           2021 Input Output (Hong Kong) Ltd.
+author:              Denis Shevchenko
+maintainer:          Denis Shevchenko <denis.shevchenko@iohk.io>
+category:            System, Network
+build-type:          Simple
+extra-doc-files:     README.md
+                     CHANGELOG.md
+
+source-repository head
+  type:                git
+  location:            https://github.com/input-output-hk/ekg-forward.git
+
+common common-options
+  build-depends:       base >=4.12 && <5
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Widentities
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wredundant-constraints
+  if impl(ghc >= 8.2)
+    ghc-options:       -fhide-source-paths
+  if impl(ghc >= 8.4)
+    ghc-options:       -Wmissing-export-lists
+                       -Wpartial-fields
+
+  default-language:    Haskell2010
+
+library
+  import:              common-options
+  hs-source-dirs:      src
+
+  exposed-modules:     System.Metrics.Acceptor
+                       System.Metrics.Configuration
+                       System.Metrics.Forwarder
+                       System.Metrics.ReqResp
+
+                       System.Metrics.Network.Acceptor
+                       System.Metrics.Network.Forwarder
+
+                       System.Metrics.Store.Acceptor
+                       System.Metrics.Store.Forwarder
+
+                       System.Metrics.Protocol.Type
+                       System.Metrics.Protocol.Codec
+                       System.Metrics.Protocol.Acceptor
+                       System.Metrics.Protocol.Forwarder
+
+  build-depends:         async
+                       , bytestring
+                       , cborg
+                       , contra-tracer
+                       , ekg-core
+                       , io-classes
+                       , network
+                       , ouroboros-network-framework >= 0.1 && < 0.3
+                       , serialise
+                       , stm
+                       , text
+                       , time
+                       , typed-protocols
+                       , typed-protocols-cborg
+                       , unordered-containers
+
+executable demo-forwarder
+  hs-source-dirs:      demo
+  main-is:             forwarder.hs
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , text
+                       , time
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+executable demo-acceptor
+  hs-source-dirs:      demo
+  main-is:             acceptor.hs
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , stm
+                       , text
+                       , time
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+test-suite ekg-forward-test
+  import:              common-options
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  other-modules:       Test.GetAllMetrics
+                       Test.GetMetrics
+                       Test.MkConfig
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , hspec
+                       , stm
+                       , time
+                       , unordered-containers
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-N
+  default-extensions:  OverloadedStrings

--- a/_sources/ekg-forward/0.2.0/meta.toml
+++ b/_sources/ekg-forward/0.2.0/meta.toml
@@ -1,2 +1,6 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/ekg-forward", rev = "9c92060de57d91f69c6792489489598991313901" }
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-09T18:29:06Z

--- a/_sources/ekg-forward/0.2.0/revisions/1.cabal
+++ b/_sources/ekg-forward/0.2.0/revisions/1.cabal
@@ -1,0 +1,128 @@
+cabal-version:       2.4
+name:                ekg-forward
+version:             0.2.0
+synopsis:            See README for more info
+description:         See README for more info
+homepage:            https://github.com/input-output-hk/ekg-forward
+bug-reports:         https://github.com/input-output-hk/ekg-forward/issues
+license:             Apache-2.0
+license-file:        LICENSE
+copyright:           2021 Input Output (Hong Kong) Ltd.
+author:              Denis Shevchenko
+maintainer:          Denis Shevchenko <denis.shevchenko@iohk.io>
+category:            System, Network
+build-type:          Simple
+extra-doc-files:     README.md
+                     CHANGELOG.md
+
+source-repository head
+  type:                git
+  location:            https://github.com/input-output-hk/ekg-forward.git
+
+common common-options
+  build-depends:       base >=4.12 && <5
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Widentities
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wredundant-constraints
+  if impl(ghc >= 8.2)
+    ghc-options:       -fhide-source-paths
+  if impl(ghc >= 8.4)
+    ghc-options:       -Wmissing-export-lists
+                       -Wpartial-fields
+
+  default-language:    Haskell2010
+
+library
+  import:              common-options
+  hs-source-dirs:      src
+
+  exposed-modules:     System.Metrics.Acceptor
+                       System.Metrics.Configuration
+                       System.Metrics.Forwarder
+                       System.Metrics.ReqResp
+
+                       System.Metrics.Network.Acceptor
+                       System.Metrics.Network.Forwarder
+
+                       System.Metrics.Store.Acceptor
+                       System.Metrics.Store.Forwarder
+
+                       System.Metrics.Protocol.Type
+                       System.Metrics.Protocol.Codec
+                       System.Metrics.Protocol.Acceptor
+                       System.Metrics.Protocol.Forwarder
+
+  build-depends:         async
+                       , bytestring
+                       , cborg
+                       , contra-tracer
+                       , ekg-core
+                       , io-classes
+                       , network
+                       , ouroboros-network-framework >= 0.1 && < 0.3
+                       , serialise
+                       , stm
+                       , text
+                       , time
+                       , typed-protocols
+                       , typed-protocols-cborg
+                       , unordered-containers
+
+executable demo-forwarder
+  hs-source-dirs:      demo
+  main-is:             forwarder.hs
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , text
+                       , time
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+executable demo-acceptor
+  hs-source-dirs:      demo
+  main-is:             acceptor.hs
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , stm
+                       , text
+                       , time
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
+                       -with-rtsopts=-T
+
+test-suite ekg-forward-test
+  import:              common-options
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  other-modules:       Test.GetAllMetrics
+                       Test.GetMetrics
+                       Test.MkConfig
+  build-depends:         base
+                       , contra-tracer
+                       , ekg-core
+                       , ekg-forward
+                       , hspec
+                       , stm
+                       , time
+                       , unordered-containers
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-N
+  default-extensions:  OverloadedStrings

--- a/_sources/trace-dispatcher/2.0.0/meta.toml
+++ b/_sources/trace-dispatcher/2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T19:32:28Z
+github = { repo = "input-output-hk/cardano-node", rev = "7d1660021b5d627c9a4ed6eb1b473ad471a5e9dd" }
+subdir = 'trace-dispatcher'

--- a/_sources/trace-forward/1.35.4/meta.toml
+++ b/_sources/trace-forward/1.35.4/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2022-11-17T04:56:26Z
 github = { repo = "input-output-hk/cardano-node", rev = "ebc7be471b30e5931b35f9bbc236d21c375b91bb" }
 subdir = 'trace-forward'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-09T17:51:37Z

--- a/_sources/trace-forward/1.35.4/revisions/1.cabal
+++ b/_sources/trace-forward/1.35.4/revisions/1.cabal
@@ -1,0 +1,101 @@
+cabal-version:   2.4
+name:            trace-forward
+version:         1.35.4
+license:         Apache-2.0
+license-file:    LICENSE
+copyright:       2021 Input Output (Hong Kong) Ltd.
+maintainer:      operations@iohk.io
+author:          IOHK
+synopsis:        The forwarding protocols library for cardano node.
+description:
+    The library providing typed protocols for forwarding different
+    information from the cardano node to an external application.
+
+build-type:      Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Trace.Forward.Protocol.DataPoint.Acceptor
+        Trace.Forward.Protocol.DataPoint.Codec
+        Trace.Forward.Protocol.DataPoint.Forwarder
+        Trace.Forward.Protocol.DataPoint.Type
+        Trace.Forward.Protocol.TraceObject.Acceptor
+        Trace.Forward.Protocol.TraceObject.Codec
+        Trace.Forward.Protocol.TraceObject.Forwarder
+        Trace.Forward.Protocol.TraceObject.Type
+        Trace.Forward.Run.DataPoint.Acceptor
+        Trace.Forward.Run.DataPoint.Forwarder
+        Trace.Forward.Run.TraceObject.Acceptor
+        Trace.Forward.Run.TraceObject.Forwarder
+        Trace.Forward.Configuration.DataPoint
+        Trace.Forward.Configuration.TraceObject
+        Trace.Forward.Utils.DataPoint
+        Trace.Forward.Utils.TraceObject
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wno-unticked-promoted-constructors
+        -Wno-orphans -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.15,
+        aeson,
+        async,
+        bytestring,
+        cborg,
+        containers,
+        contra-tracer,
+        extra,
+        io-classes,
+        ouroboros-network-framework ^>= 0.2,
+        serialise,
+        stm,
+        text,
+        typed-protocols,
+        typed-protocols-cborg
+
+test-suite test
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Trace.Forward.Protocol.TraceObject.Codec
+        Test.Trace.Forward.Protocol.TraceObject.Direct
+        Test.Trace.Forward.Protocol.TraceObject.Examples
+        Test.Trace.Forward.Protocol.TraceObject.Item
+        Test.Trace.Forward.Protocol.TraceObject.Tests
+        Test.Trace.Forward.Protocol.DataPoint.Codec
+        Test.Trace.Forward.Protocol.DataPoint.Direct
+        Test.Trace.Forward.Protocol.DataPoint.Examples
+        Test.Trace.Forward.Protocol.DataPoint.Item
+        Test.Trace.Forward.Protocol.DataPoint.Tests
+        Test.Trace.Forward.Protocol.Common
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wno-unticked-promoted-constructors
+        -Wno-orphans -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages -rtsopts -threaded
+
+    build-depends:
+        base >=4.14 && <4.15,
+        aeson,
+        bytestring,
+        contra-tracer,
+        io-classes,
+        io-sim,
+        ouroboros-network-framework,
+        trace-forward,
+        QuickCheck,
+        serialise,
+        tasty,
+        tasty-quickcheck,
+        typed-protocols,
+        text

--- a/_sources/trace-forward/2.0.0/meta.toml
+++ b/_sources/trace-forward/2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T19:32:07Z
+github = { repo = "input-output-hk/cardano-node", rev = "d62b76690f3ddabe4c4028f12f03e87905ee1c52" }
+subdir = 'trace-forward'

--- a/_sources/trace-resources/0.2.0.0/meta.toml
+++ b/_sources/trace-resources/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-09T19:32:49Z
+github = { repo = "input-output-hk/cardano-node", rev = "3fcfb4c0d7a0d78bb72906201096f88d1515392b" }
+subdir = 'trace-resources'

--- a/flake.lock
+++ b/flake.lock
@@ -317,11 +317,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1682641452,
-        "narHash": "sha256-hUBB6B7A6UWiYYHtkeu+R+Xwvqd06chBZpwskx7WG28=",
+        "lastModified": 1683591861,
+        "narHash": "sha256-TMi/ue1sZfQTm295Qb6d87XWl58JMkoSmNhpMAblzdI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "62d9abdf9eb3d0f2857663ecbf5a7f870f7a7b56",
+        "rev": "533487137fc2658349953794d8d7fa14f046e3ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is the [`8.0.0`](https://github.com/input-output-hk/cardano-node/tree/8.0.0) release of `cardano-node` packages to CHaP