### PR TITLE
ledger updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,8 @@ _sources/byron-spec-ledger       @input-output-hk/cardano-ledger
 _sources/cardano-crypto-test     @input-output-hk/cardano-ledger
 _sources/cardano-crypto-wrapper  @input-output-hk/cardano-ledger
 _sources/cardano-data            @input-output-hk/cardano-ledger
+_sources/cardano-ledger-api      @input-output-hk/cardano-ledger
+_sources/cardano-ledger-binary   @input-output-hk/cardano-ledger
 _sources/cardano-ledger-core     @input-output-hk/cardano-ledger
 _sources/cardano-ledger-pretty   @input-output-hk/cardano-ledger
 _sources/cardano-ledger-test     @input-output-hk/cardano-ledger
@@ -30,6 +32,7 @@ _sources/small-steps             @input-output-hk/cardano-ledger
 _sources/small-steps-test        @input-output-hk/cardano-ledger
 
 ## Eras
+_sources/cardano-ledger-allegra         @input-output-hk/cardano-ledger
 _sources/cardano-ledger-alonzo          @input-output-hk/cardano-ledger
 _sources/cardano-ledger-alonzo-test     @input-output-hk/cardano-ledger
 _sources/cardano-ledger-babbage         @input-output-hk/cardano-ledger
@@ -38,6 +41,7 @@ _sources/cardano-ledger-byron           @input-output-hk/cardano-ledger
 _sources/cardano-ledger-byron-test      @input-output-hk/cardano-ledger
 _sources/cardano-ledger-conway          @input-output-hk/cardano-ledger
 _sources/cardano-ledger-conway-test     @input-output-hk/cardano-ledger
+_sources/cardano-ledger-mary            @input-output-hk/cardano-ledger
 _sources/cardano-ledger-shelley         @input-output-hk/cardano-ledger
 _sources/cardano-ledger-shelley-test    @input-output-hk/cardano-ledger
 _sources/cardano-ledger-shelley-ma      @input-output-hk/cardano-ledger

--- a/_sources/cardano-data/1.1.0.0/meta.toml
+++ b/_sources/cardano-data/1.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-data'

--- a/_sources/cardano-ledger-allegra/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo-test/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage-test/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-babbage-test/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/babbage/test-suite'

--- a/_sources/cardano-ledger-babbage/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-conway-test/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-conway-test/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/conway/test-suite'

--- a/_sources/cardano-ledger-conway/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-mary/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-pretty/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-pretty/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-ledger-pretty'

--- a/_sources/cardano-ledger-shelley-ma-test/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma-test/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/shelley-ma/test-suite'

--- a/_sources/cardano-ledger-shelley-ma/1.1.0.1/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma/1.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/shelley-ma/impl'

--- a/_sources/cardano-ledger-shelley-test/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.1.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-05T21:13:03Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f10f06f6ab96b5ee52a28ccc45b41a592efde4b7" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-11T21:34:38Z

--- a/_sources/cardano-ledger-shelley/1.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/1.1.0.0/revisions/1.cabal
@@ -1,0 +1,177 @@
+cabal-version:      3.0
+name:               cardano-ledger-shelley
+version:            1.1.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           Shelley Ledger Executable Model
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger.git
+    subdir:   eras/shelley/impl
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Chain
+        Cardano.Ledger.Shelley
+        Cardano.Ledger.Shelley.Address.Bootstrap
+        Cardano.Ledger.Shelley.API
+        Cardano.Ledger.Shelley.API.ByronTranslation
+        Cardano.Ledger.Shelley.API.Genesis
+        Cardano.Ledger.Shelley.API.Validation
+        Cardano.Ledger.Shelley.API.Wallet
+        Cardano.Ledger.Shelley.API.Mempool
+        Cardano.Ledger.Shelley.API.Types
+        Cardano.Ledger.Shelley.AdaPots
+        Cardano.Ledger.Shelley.BlockChain
+        Cardano.Ledger.Shelley.Core
+        Cardano.Ledger.Shelley.Delegation.Certificates
+        Cardano.Ledger.Shelley.Delegation.PoolParams
+        Cardano.Ledger.Shelley.EpochBoundary
+        Cardano.Ledger.Shelley.Genesis
+        Cardano.Ledger.Shelley.Governance
+        Cardano.Ledger.Shelley.HardForks
+        Cardano.Ledger.Shelley.LedgerState
+        Cardano.Ledger.Shelley.Metadata
+        Cardano.Ledger.Shelley.Orphans
+        Cardano.Ledger.Shelley.PoolRank
+        Cardano.Ledger.Shelley.PoolParams
+        Cardano.Ledger.Shelley.PParams
+        Cardano.Ledger.Shelley.Rewards
+        Cardano.Ledger.Shelley.RewardProvenance
+        Cardano.Ledger.Shelley.RewardUpdate
+        Cardano.Ledger.Shelley.Scripts
+        Cardano.Ledger.Shelley.SoftForks
+        Cardano.Ledger.Shelley.StabilityWindow
+        Cardano.Ledger.Shelley.Rules
+        Cardano.Ledger.Shelley.Translation
+        Cardano.Ledger.Shelley.Tx
+        Cardano.Ledger.Shelley.TxAuxData
+        Cardano.Ledger.Shelley.TxBody
+        Cardano.Ledger.Shelley.TxOut
+        Cardano.Ledger.Shelley.TxWits
+        Cardano.Ledger.Shelley.UTxO
+        Cardano.Ledger.Shelley.Rules.Reports
+        Cardano.Ledger.Shelley.Internal
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Shelley.Era
+        Cardano.Ledger.Shelley.LedgerState.Types
+        Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+        Cardano.Ledger.Shelley.LedgerState.NewEpochState
+        Cardano.Ledger.Shelley.LedgerState.PulsingReward
+        Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits
+        Cardano.Ledger.Shelley.Rules.Bbody
+        Cardano.Ledger.Shelley.Rules.Deleg
+        Cardano.Ledger.Shelley.Rules.Delegs
+        Cardano.Ledger.Shelley.Rules.Delpl
+        Cardano.Ledger.Shelley.Rules.Epoch
+        Cardano.Ledger.Shelley.Rules.Ledger
+        Cardano.Ledger.Shelley.Rules.Ledgers
+        Cardano.Ledger.Shelley.Rules.Mir
+        Cardano.Ledger.Shelley.Rules.NewEpoch
+        Cardano.Ledger.Shelley.Rules.Newpp
+        Cardano.Ledger.Shelley.Rules.Pool
+        Cardano.Ledger.Shelley.Rules.PoolReap
+        Cardano.Ledger.Shelley.Rules.Ppup
+        Cardano.Ledger.Shelley.Rules.Rupd
+        Cardano.Ledger.Shelley.Rules.Snap
+        Cardano.Ledger.Shelley.Rules.Tick
+        Cardano.Ledger.Shelley.Rules.Upec
+        Cardano.Ledger.Shelley.Rules.Utxo
+        Cardano.Ledger.Shelley.Rules.Utxow
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0,
+        cardano-ledger-binary >=1.0,
+        cardano-ledger-byron,
+        cardano-ledger-core >=1.1,
+        cardano-slotting,
+        vector-map >=1.0,
+        containers,
+        data-default-class,
+        deepseq,
+        groups,
+        heapwords,
+        mtl,
+        microlens,
+        nothunks,
+        quiet,
+        set-algebra >=1.0,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        validation-selective
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Shelley.Arbitrary
+        Test.Cardano.Ledger.Shelley.Binary.Golden
+        Test.Cardano.Ledger.Shelley.Constants
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-crypto-class,
+        cardano-data,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        cardano-ledger-shelley,
+        containers,
+        generic-random,
+        containers,
+        vector-map,
+        mtl,
+        text,
+        hedgehog-quickcheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Shelley.Binary.GoldenSpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-shelley,
+        testlib

--- a/_sources/cardano-ledger-shelley/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.1.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-11T21:04:18Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "36cae5287cf6b83e714782dd6a8140df882b55de" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-11T21:33:43Z

--- a/_sources/cardano-ledger-shelley/1.1.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/1.1.1.0/revisions/1.cabal
@@ -1,0 +1,177 @@
+cabal-version:      3.0
+name:               cardano-ledger-shelley
+version:            1.1.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           Shelley Ledger Executable Model
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger.git
+    subdir:   eras/shelley/impl
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Chain
+        Cardano.Ledger.Shelley
+        Cardano.Ledger.Shelley.Address.Bootstrap
+        Cardano.Ledger.Shelley.API
+        Cardano.Ledger.Shelley.API.ByronTranslation
+        Cardano.Ledger.Shelley.API.Genesis
+        Cardano.Ledger.Shelley.API.Validation
+        Cardano.Ledger.Shelley.API.Wallet
+        Cardano.Ledger.Shelley.API.Mempool
+        Cardano.Ledger.Shelley.API.Types
+        Cardano.Ledger.Shelley.AdaPots
+        Cardano.Ledger.Shelley.BlockChain
+        Cardano.Ledger.Shelley.Core
+        Cardano.Ledger.Shelley.Delegation.Certificates
+        Cardano.Ledger.Shelley.Delegation.PoolParams
+        Cardano.Ledger.Shelley.EpochBoundary
+        Cardano.Ledger.Shelley.Genesis
+        Cardano.Ledger.Shelley.Governance
+        Cardano.Ledger.Shelley.HardForks
+        Cardano.Ledger.Shelley.LedgerState
+        Cardano.Ledger.Shelley.Metadata
+        Cardano.Ledger.Shelley.Orphans
+        Cardano.Ledger.Shelley.PoolRank
+        Cardano.Ledger.Shelley.PoolParams
+        Cardano.Ledger.Shelley.PParams
+        Cardano.Ledger.Shelley.Rewards
+        Cardano.Ledger.Shelley.RewardProvenance
+        Cardano.Ledger.Shelley.RewardUpdate
+        Cardano.Ledger.Shelley.Scripts
+        Cardano.Ledger.Shelley.SoftForks
+        Cardano.Ledger.Shelley.StabilityWindow
+        Cardano.Ledger.Shelley.Rules
+        Cardano.Ledger.Shelley.Translation
+        Cardano.Ledger.Shelley.Tx
+        Cardano.Ledger.Shelley.TxAuxData
+        Cardano.Ledger.Shelley.TxBody
+        Cardano.Ledger.Shelley.TxOut
+        Cardano.Ledger.Shelley.TxWits
+        Cardano.Ledger.Shelley.UTxO
+        Cardano.Ledger.Shelley.Rules.Reports
+        Cardano.Ledger.Shelley.Internal
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Shelley.Era
+        Cardano.Ledger.Shelley.LedgerState.Types
+        Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+        Cardano.Ledger.Shelley.LedgerState.NewEpochState
+        Cardano.Ledger.Shelley.LedgerState.PulsingReward
+        Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits
+        Cardano.Ledger.Shelley.Rules.Bbody
+        Cardano.Ledger.Shelley.Rules.Deleg
+        Cardano.Ledger.Shelley.Rules.Delegs
+        Cardano.Ledger.Shelley.Rules.Delpl
+        Cardano.Ledger.Shelley.Rules.Epoch
+        Cardano.Ledger.Shelley.Rules.Ledger
+        Cardano.Ledger.Shelley.Rules.Ledgers
+        Cardano.Ledger.Shelley.Rules.Mir
+        Cardano.Ledger.Shelley.Rules.NewEpoch
+        Cardano.Ledger.Shelley.Rules.Newpp
+        Cardano.Ledger.Shelley.Rules.Pool
+        Cardano.Ledger.Shelley.Rules.PoolReap
+        Cardano.Ledger.Shelley.Rules.Ppup
+        Cardano.Ledger.Shelley.Rules.Rupd
+        Cardano.Ledger.Shelley.Rules.Snap
+        Cardano.Ledger.Shelley.Rules.Tick
+        Cardano.Ledger.Shelley.Rules.Upec
+        Cardano.Ledger.Shelley.Rules.Utxo
+        Cardano.Ledger.Shelley.Rules.Utxow
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0,
+        cardano-ledger-binary >=1.0,
+        cardano-ledger-byron,
+        cardano-ledger-core ^>=1.1,
+        cardano-slotting,
+        vector-map >=1.0,
+        containers,
+        data-default-class,
+        deepseq,
+        groups,
+        heapwords,
+        mtl,
+        microlens,
+        nothunks,
+        quiet,
+        set-algebra >=1.0,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        validation-selective
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Shelley.Arbitrary
+        Test.Cardano.Ledger.Shelley.Binary.Golden
+        Test.Cardano.Ledger.Shelley.Constants
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-crypto-class,
+        cardano-data,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        cardano-ledger-shelley,
+        containers,
+        generic-random,
+        containers,
+        vector-map,
+        mtl,
+        text,
+        hedgehog-quickcheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Shelley.Binary.GoldenSpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-shelley,
+        testlib

--- a/_sources/cardano-ledger-shelley/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.0.3.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.0.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/ouroboros-consensus-cardano/0.5.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.5.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-29T17:52:58Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "e19a58d078b882e5180d9ef591a1f4e9a1987fe0" }
 subdir = 'ouroboros-consensus-cardano'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-11T21:46:07Z

--- a/_sources/ouroboros-consensus-cardano/0.5.0.1/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.5.0.1/revisions/1.cabal
@@ -1,0 +1,555 @@
+cabal-version:   3.0
+name:            ouroboros-consensus-cardano
+version:         0.5.0.1
+synopsis:
+  The instantation of the Ouroboros consensus layer used by Cardano
+
+description:
+  The instantation of the Ouroboros consensus layer used by Cardano.
+
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+common common-exe
+  import:      common-lib
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-N -I0 -A16m"
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus-cardano src/byron src/shelley
+  exposed-modules:
+    Ouroboros.Consensus.Byron.Crypto.DSIGN
+    Ouroboros.Consensus.Byron.EBBs
+    Ouroboros.Consensus.Byron.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Block
+    Ouroboros.Consensus.Byron.Ledger.Config
+    Ouroboros.Consensus.Byron.Ledger.Conversions
+    Ouroboros.Consensus.Byron.Ledger.Forge
+    Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+    Ouroboros.Consensus.Byron.Ledger.Inspect
+    Ouroboros.Consensus.Byron.Ledger.Integrity
+    Ouroboros.Consensus.Byron.Ledger.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Mempool
+    Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Byron.Ledger.Orphans
+    Ouroboros.Consensus.Byron.Ledger.PBFT
+    Ouroboros.Consensus.Byron.Ledger.Serialisation
+    Ouroboros.Consensus.Byron.Node
+    Ouroboros.Consensus.Byron.Node.Serialisation
+    Ouroboros.Consensus.Byron.Protocol
+    Ouroboros.Consensus.Cardano
+    Ouroboros.Consensus.Cardano.Block
+    Ouroboros.Consensus.Cardano.ByronHFC
+    Ouroboros.Consensus.Cardano.CanHardFork
+    Ouroboros.Consensus.Cardano.Condense
+    Ouroboros.Consensus.Cardano.Node
+    Ouroboros.Consensus.Cardano.ShelleyBased
+    Ouroboros.Consensus.Shelley.Crypto
+    Ouroboros.Consensus.Shelley.Eras
+    Ouroboros.Consensus.Shelley.HFEras
+    Ouroboros.Consensus.Shelley.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Block
+    Ouroboros.Consensus.Shelley.Ledger.Config
+    Ouroboros.Consensus.Shelley.Ledger.Forge
+    Ouroboros.Consensus.Shelley.Ledger.Inspect
+    Ouroboros.Consensus.Shelley.Ledger.Integrity
+    Ouroboros.Consensus.Shelley.Ledger.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Mempool
+    Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+    Ouroboros.Consensus.Shelley.Ledger.Protocol
+    Ouroboros.Consensus.Shelley.Ledger.Query
+    Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Shelley.Node
+    Ouroboros.Consensus.Shelley.Node.Common
+    Ouroboros.Consensus.Shelley.Node.Praos
+    Ouroboros.Consensus.Shelley.Node.Serialisation
+    Ouroboros.Consensus.Shelley.Node.TPraos
+    Ouroboros.Consensus.Shelley.Protocol.Abstract
+    Ouroboros.Consensus.Shelley.Protocol.Praos
+    Ouroboros.Consensus.Shelley.Protocol.TPraos
+    Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  build-depends:
+    , base                          >=4.14  && <4.17
+    , base-deriving-via
+    , bytestring                    >=0.10  && <0.12
+    , cardano-binary
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core           ^>=1.1
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-prelude
+    , cardano-protocol-tpraos       >=1.0.1 && <1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                         >=0.2.2 && <0.3
+    , containers                    >=0.5   && <0.7
+    , cryptonite                    >=0.25  && <0.31
+    , deepseq
+    , formatting                    >=6.3   && <7.2
+    , measures
+    , microlens
+    , mtl                           >=2.2   && <2.3
+    , nothunks
+    , ouroboros-consensus           >=0.5   && <0.7
+    , ouroboros-consensus-protocol  ^>=0.5
+    , ouroboros-network-api         ^>=0.3
+    , serialise                     >=0.2   && <0.3
+    , small-steps
+    , text                          >=1.2   && <1.3
+    , these                         >=1.1   && <1.2
+    , vector-map
+
+library byronspec
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs:  src/byronspec
+  exposed-modules:
+    Ouroboros.Consensus.ByronSpec.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Accessors
+    Ouroboros.Consensus.ByronSpec.Ledger.Block
+    Ouroboros.Consensus.ByronSpec.Ledger.Conversions
+    Ouroboros.Consensus.ByronSpec.Ledger.Forge
+    Ouroboros.Consensus.ByronSpec.Ledger.Genesis
+    Ouroboros.Consensus.ByronSpec.Ledger.GenTx
+    Ouroboros.Consensus.ByronSpec.Ledger.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Mempool
+    Ouroboros.Consensus.ByronSpec.Ledger.Orphans
+    Ouroboros.Consensus.ByronSpec.Ledger.Rules
+
+  build-depends:
+    , base                       >=4.14  && <4.17
+    , bimap                      >=0.4   && <0.5
+    , byron-spec-chain
+    , byron-spec-ledger
+    , cardano-ledger-binary
+    , cardano-ledger-byron-test
+    , cborg                      >=0.2.2 && <0.3
+    , containers                 >=0.5   && <0.7
+    , mtl                        >=2.2   && <2.3
+    , nothunks
+    , ouroboros-consensus        >=0.5   && <0.7
+    , serialise                  >=0.2   && <0.3
+    , small-steps
+    , transformers
+
+library byron-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs:  src/byron-testlib
+  exposed-modules:
+    Ouroboros.Consensus.ByronDual.Ledger
+    Ouroboros.Consensus.ByronDual.Node
+    Ouroboros.Consensus.ByronDual.Node.Serialisation
+    Test.Consensus.Byron.Examples
+    Test.Consensus.Byron.Generators
+    Test.ThreadNet.Infra.Byron
+    Test.ThreadNet.Infra.Byron.Genesis
+    Test.ThreadNet.Infra.Byron.ProtocolInfo
+    Test.ThreadNet.Infra.Byron.TrackUpdates
+    Test.ThreadNet.TxGen.Byron
+
+  build-depends:
+    , base
+    , byron-spec-ledger
+    , byronspec
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-test
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , containers
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , serialise
+
+test-suite byron-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/byron-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Byron.Golden
+    Test.Consensus.Byron.Serialisation
+    Test.ThreadNet.Byron
+    Test.ThreadNet.DualByron
+
+  build-depends:
+    , base
+    , binary-search
+    , byron-spec-chain
+    , byron-spec-ledger
+    , byron-testlib
+    , byronspec
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , cborg
+    , containers
+    , filepath
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-mock
+    , QuickCheck
+    , small-steps
+    , small-steps-test
+    , tasty
+    , tasty-quickcheck
+
+library shelley-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs:  src/shelley-testlib
+  exposed-modules:
+    Test.Consensus.Shelley.Examples
+    Test.Consensus.Shelley.Generators
+    Test.Consensus.Shelley.MockCrypto
+    Test.ThreadNet.Infra.Alonzo
+    Test.ThreadNet.Infra.Shelley
+    Test.ThreadNet.TxGen.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-babbage
+    , cardano-ledger-babbage-test
+    , cardano-ledger-conway-test
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-mary
+    , cardano-ledger-shelley-ma-test
+    , cardano-ledger-shelley-test
+    , cardano-ledger-shelley:{cardano-ledger-shelley, testlib}
+    , cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib}
+    , cardano-strict-containers
+    , containers
+    , generic-random
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , quiet                                                                          >=0.2 && <0.3
+    , small-steps
+
+test-suite shelley-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/shelley-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Shelley.Coherence
+    Test.Consensus.Shelley.Golden
+    Test.Consensus.Shelley.Serialisation
+    Test.ThreadNet.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cborg
+    , containers
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , shelley-testlib
+    , tasty
+    , tasty-quickcheck
+
+library cardano-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs:  src/cardano-testlib
+  exposed-modules:
+    Test.Consensus.Cardano.Examples
+    Test.Consensus.Cardano.Generators
+    Test.Consensus.Cardano.MockCrypto
+    Test.ThreadNet.Infra.ShelleyBasedHardFork
+    Test.ThreadNet.Infra.TwoEras
+    Test.ThreadNet.TxGen.Allegra
+    Test.ThreadNet.TxGen.Alonzo
+    Test.ThreadNet.TxGen.Babbage
+    Test.ThreadNet.TxGen.Cardano
+    Test.ThreadNet.TxGen.Mary
+
+  build-depends:
+    , base
+    , byron-testlib
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-byron
+    , cardano-ledger-conway-test
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cardano-strict-containers
+    , containers
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:{ouroboros-consensus-diffusion, diffusion-testlib}
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , shelley-testlib
+
+test-suite cardano-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/cardano-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Cardano.ByronCompatibility
+    Test.Consensus.Cardano.Golden
+    Test.Consensus.Cardano.Serialisation
+    Test.ThreadNet.AllegraMary
+    Test.ThreadNet.Cardano
+    Test.ThreadNet.MaryAlonzo
+    Test.ThreadNet.ShelleyAllegra
+
+  build-depends:
+    , base
+    , byron-testlib
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cardano-testlib
+    , cborg
+    , containers
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , shelley-testlib
+    , sop-core
+    , tasty
+    , tasty-quickcheck
+
+library cardano-tools
+  import:          common-lib
+  hs-source-dirs:  src/tools
+  visibility:      public
+  exposed-modules:
+    Cardano.Api.Any
+    Cardano.Api.Protocol.Types
+    Cardano.Node.Protocol
+    Cardano.Node.Protocol.Types
+    Cardano.Node.Types
+    Cardano.Tools.DBAnalyser.Analysis
+    Cardano.Tools.DBAnalyser.Block.Byron
+    Cardano.Tools.DBAnalyser.Block.Cardano
+    Cardano.Tools.DBAnalyser.Block.Shelley
+    Cardano.Tools.DBAnalyser.HasAnalysis
+    Cardano.Tools.DBAnalyser.Run
+    Cardano.Tools.DBAnalyser.Types
+    Cardano.Tools.DBSynthesizer.Forging
+    Cardano.Tools.DBSynthesizer.Orphans
+    Cardano.Tools.DBSynthesizer.Run
+    Cardano.Tools.DBSynthesizer.Types
+
+  other-modules:
+    Cardano.Api.Key
+    Cardano.Api.KeysByron
+    Cardano.Api.KeysPraos
+    Cardano.Api.KeysShelley
+    Cardano.Api.OperationalCertificate
+    Cardano.Api.SerialiseTextEnvelope
+    Cardano.Api.SerialiseUsing
+    Cardano.Node.Protocol.Alonzo
+    Cardano.Node.Protocol.Byron
+    Cardano.Node.Protocol.Cardano
+    Cardano.Node.Protocol.Conway
+    Cardano.Node.Protocol.Shelley
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
+
+  build-depends:
+    , aeson
+    , base                           >=4.14  && <4.17
+    , base16-bytestring              >=1.0
+    , bytestring                     >=0.10  && <0.12
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-prelude
+    , cardano-protocol-tpraos        >=1.0.1 && <1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                          >=0.2.2 && <0.3
+    , containers                     >=0.5   && <0.7
+    , contra-tracer
+    , directory
+    , filepath
+    , fs-api
+    , microlens
+    , mtl                            >=2.2   && <2.3
+    , nothunks
+    , ouroboros-consensus            >=0.5   && <0.7
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion  ^>=0.5
+    , ouroboros-consensus-protocol   ^>=0.5
+    , ouroboros-network-api
+    , serialise                      >=0.2   && <0.3
+    , text                           >=1.2   && <1.3
+    , text-builder
+    , transformers
+    , transformers-except
+
+executable db-analyser
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-analyser.hs
+  build-depends:
+    , base
+    , cardano-crypto-wrapper
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-tools}
+
+  other-modules:  DBAnalyser.Parsers
+
+executable db-synthesizer
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-synthesizer.hs
+  build-depends:
+    , base
+    , cardano-tools
+    , optparse-applicative
+    , ouroboros-consensus
+
+  other-modules:  DBSynthesizer.Parsers
+
+test-suite tools-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/tools-test
+  main-is:        Main.hs
+  build-depends:
+    , base
+    , cardano-tools
+    , tasty
+    , tasty-hunit

--- a/_sources/set-algebra/1.1.0.0/meta.toml
+++ b/_sources/set-algebra/1.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-11T21:41:19Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
+subdir = 'libs/set-algebra'


### PR DESCRIPTION
I am updating several packages from ledger. The biggest change is support for Plutus V3 starting in the conway ledger era.

- cardano-ledger-babbage - 1.2.0.0
- cardano-ledger-babbage-test - 1.1.1.0
- cardano-ledger-mary - 1.2.0.0
- cardano-ledger-allegra - 1.1.1.0
- cardano-ledger-conway - 1.2.0.0
- cardano-ledger-conway-test - 1.1.1.0
- cardano-ledger-alonzo - 1.2.0.0
- cardano-ledger-alonzo-test - 1.1.1.0
- cardano-ledger-shelley - 1.2.0.0
- cardano-ledger-shelley-test - 1.1.1.0
- cardano-ledger-binary - 1.1.1.0
- cardano-ledger-api - 1.2.0.0
- cardano-ledger-pretty - 1.1.1.0
- cardano-data - 1.1.0.0
- cardano-ledger-core - 1.2.0.0
- cardano-protocol-tpraos - 1.0.3.0
- cardano-shelley-ma - 1.1.0.1
- cardano-shelley-ma - 1.2.0.0
- set-algebra - 1.1.0.0

I also updated the `CODEOWNERS` file to include these ledger packages:
- cardano-ledger-api
- cardano-ledger-binary
- cardano-ledger-allegra
- cardano-ledger-mary

I also added revisions:
* cardano-ledger-shelley 1.1.1.0 -> new upper bound on cardano-ledger-core ^>=1.1
* cardano-ledger-shelley 1.1.0.0 -> new upper bound on cardano-ledger-core ^>=1.1
* ouroboros-consensus-cardano 0.5.0.1 -> new upper bound an on cardano-ledger-core ^>=1.1