### PR TITLE
cardano-ledger-shelley 1.1.1.1 revision

### DIFF
--- a/_sources/cardano-ledger-shelley/1.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-26T17:24:56Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "55a58ad476a978a24d56e8ce28b5f4bbaa159169" }
 subdir = 'eras/shelley/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-10T20:07:14Z

--- a/_sources/cardano-ledger-shelley/1.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-shelley/1.1.1.1/revisions/1.cabal
@@ -1,0 +1,177 @@
+cabal-version:      3.0
+name:               cardano-ledger-shelley
+version:            1.1.1.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           Shelley Ledger Executable Model
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger.git
+    subdir:   eras/shelley/impl
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Chain
+        Cardano.Ledger.Shelley
+        Cardano.Ledger.Shelley.Address.Bootstrap
+        Cardano.Ledger.Shelley.API
+        Cardano.Ledger.Shelley.API.ByronTranslation
+        Cardano.Ledger.Shelley.API.Genesis
+        Cardano.Ledger.Shelley.API.Validation
+        Cardano.Ledger.Shelley.API.Wallet
+        Cardano.Ledger.Shelley.API.Mempool
+        Cardano.Ledger.Shelley.API.Types
+        Cardano.Ledger.Shelley.AdaPots
+        Cardano.Ledger.Shelley.BlockChain
+        Cardano.Ledger.Shelley.Core
+        Cardano.Ledger.Shelley.Delegation.Certificates
+        Cardano.Ledger.Shelley.Delegation.PoolParams
+        Cardano.Ledger.Shelley.EpochBoundary
+        Cardano.Ledger.Shelley.Genesis
+        Cardano.Ledger.Shelley.Governance
+        Cardano.Ledger.Shelley.HardForks
+        Cardano.Ledger.Shelley.LedgerState
+        Cardano.Ledger.Shelley.Metadata
+        Cardano.Ledger.Shelley.Orphans
+        Cardano.Ledger.Shelley.PoolRank
+        Cardano.Ledger.Shelley.PoolParams
+        Cardano.Ledger.Shelley.PParams
+        Cardano.Ledger.Shelley.Rewards
+        Cardano.Ledger.Shelley.RewardProvenance
+        Cardano.Ledger.Shelley.RewardUpdate
+        Cardano.Ledger.Shelley.Scripts
+        Cardano.Ledger.Shelley.SoftForks
+        Cardano.Ledger.Shelley.StabilityWindow
+        Cardano.Ledger.Shelley.Rules
+        Cardano.Ledger.Shelley.Translation
+        Cardano.Ledger.Shelley.Tx
+        Cardano.Ledger.Shelley.TxAuxData
+        Cardano.Ledger.Shelley.TxBody
+        Cardano.Ledger.Shelley.TxOut
+        Cardano.Ledger.Shelley.TxWits
+        Cardano.Ledger.Shelley.UTxO
+        Cardano.Ledger.Shelley.Rules.Reports
+        Cardano.Ledger.Shelley.Internal
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Shelley.Era
+        Cardano.Ledger.Shelley.LedgerState.Types
+        Cardano.Ledger.Shelley.LedgerState.IncrementalStake
+        Cardano.Ledger.Shelley.LedgerState.NewEpochState
+        Cardano.Ledger.Shelley.LedgerState.PulsingReward
+        Cardano.Ledger.Shelley.LedgerState.RefundsAndDeposits
+        Cardano.Ledger.Shelley.Rules.Bbody
+        Cardano.Ledger.Shelley.Rules.Deleg
+        Cardano.Ledger.Shelley.Rules.Delegs
+        Cardano.Ledger.Shelley.Rules.Delpl
+        Cardano.Ledger.Shelley.Rules.Epoch
+        Cardano.Ledger.Shelley.Rules.Ledger
+        Cardano.Ledger.Shelley.Rules.Ledgers
+        Cardano.Ledger.Shelley.Rules.Mir
+        Cardano.Ledger.Shelley.Rules.NewEpoch
+        Cardano.Ledger.Shelley.Rules.Newpp
+        Cardano.Ledger.Shelley.Rules.Pool
+        Cardano.Ledger.Shelley.Rules.PoolReap
+        Cardano.Ledger.Shelley.Rules.Ppup
+        Cardano.Ledger.Shelley.Rules.Rupd
+        Cardano.Ledger.Shelley.Rules.Snap
+        Cardano.Ledger.Shelley.Rules.Tick
+        Cardano.Ledger.Shelley.Rules.Upec
+        Cardano.Ledger.Shelley.Rules.Utxo
+        Cardano.Ledger.Shelley.Rules.Utxow
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0,
+        cardano-ledger-binary >=1.0,
+        cardano-ledger-byron,
+        cardano-ledger-core ^>=1.1,
+        cardano-slotting,
+        vector-map >=1.0,
+        containers,
+        data-default-class,
+        deepseq,
+        groups,
+        heapwords,
+        mtl,
+        microlens,
+        nothunks,
+        quiet,
+        set-algebra >=1.0,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        validation-selective
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Shelley.Arbitrary
+        Test.Cardano.Ledger.Shelley.Binary.Golden
+        Test.Cardano.Ledger.Shelley.Constants
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-crypto-class,
+        cardano-data,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        cardano-ledger-shelley,
+        containers,
+        generic-random,
+        containers,
+        vector-map,
+        mtl,
+        text,
+        hedgehog-quickcheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Ledger.Shelley.Binary.GoldenSpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-shelley,
+        testlib


### PR DESCRIPTION
Adding  an upper bound in `cardano-ledger-shelley 1.1.1.1` on `cardano-ledger-core ^>=1.1`
