### PR TITLE
Revision: cardano-crypto-wrapper-1.4.2 needs cardano-binary < 1.5.0.1

### DIFF
--- a/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/byron/crypto'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:32:34Z
+
+[[revisions]]
+number = 2
+timestamp = 2023-05-15T03:47:48Z

--- a/_sources/cardano-crypto-wrapper/1.4.2/revisions/2.cabal
+++ b/_sources/cardano-crypto-wrapper/1.4.2/revisions/2.cabal
@@ -1,0 +1,139 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.4.2
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+data-files:          test/golden/AbstractHash
+                     test/golden/DecShare
+                     test/golden/EncShare
+                     test/golden/PassPhrase
+                     test/golden/RedeemSignature
+                     test/golden/RedeemSigningKey
+                     test/golden/RedeemVerificationKey
+                     test/golden/Secret
+                     test/golden/SecretProof
+                     test/golden/Signature
+                     test/golden/SigningKey
+                     test/golden/VerificationKey
+                     test/golden/VssPublicKey
+                     test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary < 1.5.0.1
+                     , cardano-crypto
+                     , cardano-prelude >= 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , heapwords
+                     , memory
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+                       Paths_cardano_crypto_wrapper
+                       GetDataFileName
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , memory
+
+  ghc-options:         -threaded
+                       -rtsopts


### PR DESCRIPTION
Add missing bound.

Build failure can be reproduced with
```
nix build --override-input CHaP github:input-output-hk/cardano-haskell-packages/8132844 \
    '.#"ghc8107/cardano-crypto-wrapper/1.4.2"'
```

Evidence that this fixes it needs a local checkout (unfortunately):
```
nix develop -c foliage build
nix build --override-input CHaP path:_repo '.#"ghc8107/cardano-crypto-wrapper/1.4.2"'
```
