### PR TITLE
Add shortcut to quickly add constraints to packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1678854831,
-        "narHash": "sha256-HzXVzCPJSnJGxatqOmbcLc23qDHvF4itTkqk4oxi3dk=",
+        "lastModified": 1683730200,
+        "narHash": "sha256-F2jCz8dFEpdEz0J6t7cqfHuL4zfRzgIKKubkYxpsWWc=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "329015d09ac4dc74a97226d0aa5b1705e2c1d52f",
+        "rev": "8132844c9956a00d27838b7fec2a1f7adea47504",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1683730200,
-        "narHash": "sha256-F2jCz8dFEpdEz0J6t7cqfHuL4zfRzgIKKubkYxpsWWc=",
+        "lastModified": 1678854831,
+        "narHash": "sha256-HzXVzCPJSnJGxatqOmbcLc23qDHvF4itTkqk4oxi3dk=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "8132844c9956a00d27838b7fec2a1f7adea47504",
+        "rev": "329015d09ac4dc74a97226d0aa5b1705e2c1d52f",
         "type": "github"
       },
       "original": {

--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -16,6 +16,14 @@ let
     let
       package-id = "${package-name}-${package-version}";
 
+      # Global config needed to build CHaP packages should go here. Obviously
+      # this should be kept to an absolute minimum, since that means config
+      # that every downstream project needs also.
+      #
+      # No need to set index-state:
+      # - haskell.nix will automatically use the latest known one for hackage
+      # - we want the very latest state for CHaP so it includes anything from
+      #   e.g. a PR being tested
       project = (pkgs.haskell-nix.cabalProject' {
         inherit compiler-nix-name;
 
@@ -42,6 +50,19 @@ let
         }];
       });
 
+      # Wrapper around all package components
+      #
+      # The wrapper also provides shortcuts to quickly manipulate the cabal project.
+      #
+      # - addCabalProject adds arbitrary configuration to the project's cabalProjectLocal
+      # - addConstraint uses addCabalProject to add a "constraints: " stanza
+      # - allowNewer uses addCabalProject to add a "allow-newer: " stanza
+      #
+      # Note 1: We use cabalProjectLocal to be able to override cabalProject
+      # Note 2: `cabalProjectLocal` ends up being prepended to the existing one
+      # rather than appended. I think this is haskell.nix bug. If the project
+      # has already a `cabalProjectLocal` this might not give the intended
+      # result.
       aggregate = project:
         pkgs.releaseTools.aggregate
           {
@@ -52,11 +73,9 @@ let
             constituents = haskellLib.getAllComponents project.hsPkgs.${package-name};
           } // {
           passthru = {
+            # pass through the project for debugging purposes
             inherit project;
-            # We use cabalProjectLocal to be able to override cabalProject
-            # Note: `cabalProjectLocal` ends up being prepended to the
-            # existing one rather than appended. If the project has already
-            # a `cabalProjectLocal` this might not give the intended result
+            # Shortcuts to manipulate the project, see above
             addCabalProject = cabalProjectLocal: aggregate (
               project.appendModule { inherit cabalProjectLocal; }
             );


### PR DESCRIPTION
This adds a function to the derivations passthru to be able to quickly add constraints to builds.

E.g. if `.#"ghc8107/cardano-ledger-core/0.1.0.0"` is an derivation that aggregates all components of `cardano-ledger-core-0.1.0.0` then

```
.#"ghc8107/cardano-ledger-core/0.1.0.0".passthru.addConstraint "cardano-crypto-class <2.0.0.1, cardano-binary<1.5.0.1"
```
builds the same aggregates with the additional listed constraints.

Usage from the command line is a bit awkward because nix being ... nix, but we can script over it:

```
nix build $(nix eval --raw '.#"ghc8107/cardano-ledger-core/0.1.0.0"' \
    --apply 'd: (d.passthru.addConstraint "cardano-crypto-class <2.0.0.1, cardano-binary<1.5.0.1").drvPath')
```

Unfortunately there's no `nix build --apply` ([yet](https://github.com/NixOS/nix/pull/6333)), so I have to do it in two steps.
