### PR TITLE
Disable iog-contra-tracer (base < 0)

### DIFF
--- a/_sources/iog-contra-tracer/0.1.0.2/meta.toml
+++ b/_sources/iog-contra-tracer/0.1.0.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-12T01:10:29Z
 github = { repo = "input-output-hk/iohk-monitoring-framework/", rev = "d3a461998a45c25a842c919545b39284726fbbb1" }
 subdir = 'iog-contra-tracer'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-15T05:28:26Z

--- a/_sources/iog-contra-tracer/0.1.0.2/revisions/1.cabal
+++ b/_sources/iog-contra-tracer/0.1.0.2/revisions/1.cabal
@@ -1,0 +1,24 @@
+name:                iog-contra-tracer
+version:             0.1.0.2
+synopsis:            A simple interface for logging, tracing or monitoring.
+-- description:
+license:             Apache-2.0
+license-files:       LICENSE, NOTICE
+author:              Neil Davies, Alexander Diemand, Andreas Triantafyllos
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Logging
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Control.Tracer
+                       Control.Tracer.Observe
+
+  default-language:    Haskell2010
+  build-depends:       base < 0
+  if impl(ghc < 8.5)
+    build-depends:     contravariant
+  ghc-options:         -Wall -Werror


### PR DESCRIPTION
This should cause all packages that use `iog-contra-tracer` to fall back to a previous version which uses `contra-tracer` (ie before the rename).

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
