### PR TITLE
Add revision for `ouroboros-network-protocols 0.5.0.1`

### DIFF
--- a/_sources/ouroboros-network-protocols/0.5.0.1/meta.toml
+++ b/_sources/ouroboros-network-protocols/0.5.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-10T04:41:56Z
 github = { repo = "input-output-hk/ouroboros-network", rev = "d1d3e4b1ce783572a643103d9799a2a8a5e7159a" }
 subdir = 'ouroboros-network-protocols'
+
+[[revisions]]
+number = 1
+timestamp = 2023-05-15T09:30:00Z

--- a/_sources/ouroboros-network-protocols/0.5.0.1/revisions/1.cabal
+++ b/_sources/ouroboros-network-protocols/0.5.0.1/revisions/1.cabal
@@ -1,0 +1,247 @@
+cabal-version:          3.0
+name:                   ouroboros-network-protocols
+version:                0.5.0.1
+synopsis:               Ouroboros Network Protocols
+description:            Ouroboros Network Protocols.
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+copyright:              2019-2023 Input Output Global Inc (IOG)
+author:                 Alexander Vieth, Marcin Szamotulski, Duncan Coutts
+maintainer:             marcin.szamotulski@iohk.io
+category:               Network
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag cddl
+  Description: Enable CDDL based tests of the CBOR encoding
+  Manual: True
+  -- These tests need the cddl and the cbor-diag Ruby-package
+  Default: True
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+library
+  hs-source-dirs:      src
+
+  -- At this experiment/prototype stage everything is exposed.
+  -- This has to be tidied up once the design becomes clear.
+  exposed-modules:
+                       Ouroboros.Network.Protocol.ChainSync.Client
+                       Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+                       Ouroboros.Network.Protocol.ChainSync.Codec
+                       Ouroboros.Network.Protocol.ChainSync.Server
+                       Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                       Ouroboros.Network.Protocol.BlockFetch.Type
+                       Ouroboros.Network.Protocol.BlockFetch.Client
+                       Ouroboros.Network.Protocol.BlockFetch.Server
+                       Ouroboros.Network.Protocol.BlockFetch.Codec
+                       Ouroboros.Network.Protocol.LocalStateQuery.Client
+                       Ouroboros.Network.Protocol.LocalStateQuery.Codec
+                       Ouroboros.Network.Protocol.LocalStateQuery.Server
+                       Ouroboros.Network.Protocol.LocalStateQuery.Type
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Type
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Client
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Server
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Codec
+                       Ouroboros.Network.Protocol.TxSubmission2.Type
+                       Ouroboros.Network.Protocol.TxSubmission2.Codec
+                       Ouroboros.Network.Protocol.TxSubmission2.Client
+                       Ouroboros.Network.Protocol.TxSubmission2.Server
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Type
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Client
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Server
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Codec
+                       Ouroboros.Network.Protocol.KeepAlive.Type
+                       Ouroboros.Network.Protocol.KeepAlive.Client
+                       Ouroboros.Network.Protocol.KeepAlive.Server
+                       Ouroboros.Network.Protocol.KeepAlive.Codec
+                       Ouroboros.Network.Protocol.PeerSharing.Type
+                       Ouroboros.Network.Protocol.PeerSharing.Client
+                       Ouroboros.Network.Protocol.PeerSharing.Server
+                       Ouroboros.Network.Protocol.PeerSharing.Codec
+
+  default-language:    Haskell2010
+  other-extensions:    BangPatterns,
+                       DataKinds,
+                       EmptyCase,
+                       ExistentialQuantification,
+                       FlexibleContexts,
+                       FlexibleInstances,
+                       FunctionalDependencies,
+                       GADTs,
+                       GADTSyntax,
+                       GeneralizedNewtypeDeriving,
+                       MultiParamTypeClasses,
+                       NamedFieldPuns,
+                       OverloadedStrings,
+                       PolyKinds,
+                       RankNTypes,
+                       RecordWildCards,
+                       ScopedTypeVariables,
+                       TemplateHaskell,
+                       TupleSections,
+                       TypeApplications,
+                       TypeFamilies,
+                       TypeInType
+
+  build-depends:       base              >=4.14 && <4.19,
+                       bytestring        >=0.10 && <0.12,
+                       cborg             >=0.2.1 && <0.3,
+
+                       io-classes       ^>=1.1,
+                       si-timers,
+
+                       ouroboros-network-api ^>=0.4,
+                       serialise,
+                       typed-protocols   >=0.1.0.4 && <1.0,
+                       typed-protocols-cborg
+                                         >=0.1 && <1.0
+
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wunused-packages
+  if flag(asserts)
+    ghc-options:       -fno-ignore-asserts
+
+library testlib
+  visibility:          public
+  hs-source-dirs:      testlib
+  default-language:    Haskell2010
+  exposed-modules:
+                       Ouroboros.Network.Protocol.BlockFetch.Direct
+                       Ouroboros.Network.Protocol.BlockFetch.Examples
+                       Ouroboros.Network.Protocol.BlockFetch.Test
+                       Ouroboros.Network.Protocol.ChainSync.Direct
+                       Ouroboros.Network.Protocol.ChainSync.DirectPipelined
+                       Ouroboros.Network.Protocol.ChainSync.Examples
+                       Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
+                       Ouroboros.Network.Protocol.ChainSync.Test
+                       Ouroboros.Network.Protocol.Handshake.Direct
+                       Ouroboros.Network.Protocol.Handshake.Test
+                       Ouroboros.Network.Protocol.LocalStateQuery.Direct
+                       Ouroboros.Network.Protocol.LocalStateQuery.Examples
+                       Ouroboros.Network.Protocol.LocalStateQuery.Test
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Direct
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Examples
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Test
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Direct
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Examples
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Test
+                       Ouroboros.Network.Protocol.TxSubmission2.Direct
+                       Ouroboros.Network.Protocol.TxSubmission2.Test
+                       Ouroboros.Network.Protocol.TxSubmission2.Examples
+                       Ouroboros.Network.Protocol.KeepAlive.Direct
+                       Ouroboros.Network.Protocol.KeepAlive.Examples
+                       Ouroboros.Network.Protocol.KeepAlive.Test
+                       Ouroboros.Network.Protocol.PeerSharing.Direct
+                       Ouroboros.Network.Protocol.PeerSharing.Examples
+                       Ouroboros.Network.Protocol.PeerSharing.Test
+
+                       Test.ChainGenerators
+                       Test.ChainProducerState
+                       Test.Ouroboros.Network.Testing.Utils
+  build-depends:       base >=4.14 && <4.19,
+                       bytestring,
+                       cborg,
+                       containers,
+                       pipes,
+                       QuickCheck,
+                       quickcheck-instances,
+                       serialise,
+                       cardano-strict-containers,
+                       tasty,
+                       tasty-quickcheck,
+                       text,
+
+                       contra-tracer,
+
+                       io-classes,
+                       io-sim,
+                       network-mux,
+                       ouroboros-network-api,
+                       ouroboros-network-framework,
+                       ouroboros-network-mock,
+                       ouroboros-network-protocols,
+                       si-timers,
+                       strict-stm,
+                       typed-protocols
+
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wunused-packages
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  -- TODO: these two tests should be moved to `ouroboros-network-mock`
+  other-modules:       Test.AnchoredFragment
+                       Test.Chain
+  default-language:    Haskell2010
+  build-depends:       base >=4.14 && <4.19,
+                       QuickCheck,
+                       tasty,
+                       tasty-quickcheck,
+
+                       ouroboros-network-api,
+                       ouroboros-network-mock,
+                       ouroboros-network-protocols:testlib,
+                       ouroboros-network-testing ^>= 0.3
+
+  ghc-options:         -Wall
+                       -Wunused-packages
+
+test-suite cddl
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test-cddl
+  main-is:             Main.hs
+  if flag(cddl)
+    buildable: True
+  else
+    buildable: False
+  default-language:    Haskell2010
+  build-depends:       base >=4.14 && <4.19,
+                       bytestring,
+                       cborg,
+                       containers,
+                       directory,
+                       filepath,
+                       mtl,
+                       process-extras,
+                       serialise,
+                       text,
+                       temporary,
+                       network,
+
+                       QuickCheck,
+                       quickcheck-instances,
+                       tasty,
+                       tasty-hunit,
+                       tasty-quickcheck,
+
+                       typed-protocols,
+                       ouroboros-network-api,
+                       ouroboros-network-framework,
+                       ouroboros-network-mock,
+                       ouroboros-network-protocols,
+                       ouroboros-network-protocols:testlib
+
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wcompat
+                       -Wunused-packages

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
             "cardano-ledger-api"
             "ouroboros-network"
             "ouroboros-consensus-cardano"
+            "ouroboros-consensus-diffusion"
             "cardano-api"
             "cardano-node"
             # from plutus-apps


### PR DESCRIPTION
`ouroboros-network-protocols` 0.5.0.1 is not compatible with `ouroboros-network-api` 0.3.0.0.

Also adds `ouroboros-consensus-diffusion` as a top-level package for the smoke tests.
