### PR TITLE
scripts/add-revision.sh: Improve error reporting

### DIFF
--- a/scripts/add-revision.sh
+++ b/scripts/add-revision.sh
@@ -49,7 +49,10 @@ fi
 CURRENT_CABAL_FILE="$BUILT_REPO/index/$PKG_NAME/$PKG_VERSION/$PKG_NAME.cabal"
 
 if [[ ! -f "$CURRENT_CABAL_FILE" ]]; then
-  echo "Current cabal file $CURRENT_CABAL_FILE does not exist"
+  echo "Current cabal file $CURRENT_CABAL_FILE does not exist."
+  DEST_DIR=$(basename "$CURRENT_CABAL_FILE")
+  mkdir -p "$DEST_DIR"
+  echo "You can copy the correct version of the cabal file to: $DEST_DIR"
   exit 1
 fi
 


### PR DESCRIPTION
I looked into actually retrieving the needed cabal file but that seems a little too fragile, so report the error, create the required  directory and suggest copying the needed cabal file. 