### PR TITLE
typed-protocols switched back to using contra-tracer

### DIFF
--- a/_sources/typed-protocols-cborg/0.1.0.4/meta.toml
+++ b/_sources/typed-protocols-cborg/0.1.0.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-16T08:11:15Z
+github = { repo = "input-output-hk/typed-protocols", rev = "071fed3c912a15fe4d86cd33db160eab40707857" }
+subdir = 'typed-protocols-cborg'

--- a/_sources/typed-protocols-examples/0.2.0.2/meta.toml
+++ b/_sources/typed-protocols-examples/0.2.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-16T08:11:15Z
+github = { repo = "input-output-hk/typed-protocols", rev = "071fed3c912a15fe4d86cd33db160eab40707857" }
+subdir = 'typed-protocols-examples'

--- a/_sources/typed-protocols/0.1.0.6/meta.toml
+++ b/_sources/typed-protocols/0.1.0.6/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-16T08:11:15Z
+github = { repo = "input-output-hk/typed-protocols", rev = "071fed3c912a15fe4d86cd33db160eab40707857" }
+subdir = 'typed-protocols'


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
