### PR TITLE
Update foliage url and bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -257,6 +257,9 @@
         "flake-utils": [
           "flake-utils"
         ],
+        "hackage-nix": [
+          "hackage-nix"
+        ],
         "haskell-nix": [
           "haskell-nix"
         ],
@@ -265,15 +268,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1678426162,
-        "narHash": "sha256-ECsiaYGvMVMgjxiWwJjUWZZxAux74imw/PL6tr5ZXeQ=",
-        "owner": "andreabedini",
+        "lastModified": 1684144463,
+        "narHash": "sha256-drQsOIK27DHeIEKqQqwox5D+kwGaPfjzBKSIKwFbP9k=",
+        "owner": "input-output-hk",
         "repo": "foliage",
-        "rev": "234f8fcbf1f953e93c56fff8fb1691c4d6b28c55",
+        "rev": "9a1eaafe734fb0768ffff4890e24439f0284c449",
         "type": "github"
       },
       "original": {
-        "owner": "andreabedini",
+        "owner": "input-output-hk",
         "repo": "foliage",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,10 @@
     flake-utils.follows = "haskell-nix/flake-utils";
 
     foliage = {
-      url = "github:andreabedini/foliage";
+      url = "github:input-output-hk/foliage";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.haskell-nix.follows = "haskell-nix";
+      inputs.hackage-nix.follows = "hackage-nix";
       inputs.flake-utils.follows = "flake-utils";
     };
 
@@ -64,7 +65,7 @@
             let
               derivations = compiler: lib.recurseIntoAttrs (lib.mapAttrs
                 (name: versions: (lib.recurseIntoAttrs (lib.genAttrs versions (version: builder compiler name version))))
-                 pkg-versions);
+                pkg-versions);
               # A nested tree of derivations containing all the packages for all the compiler versions
               perCompilerDerivations = lib.recurseIntoAttrs (lib.genAttrs compilers derivations);
               # cardano-node/cardano-api can't build on 9.2 yet
@@ -83,7 +84,8 @@
                 (lib.setAttrByPath [ "ghc926" "quickcheck-contractmodel" ] null)
               ];
               filtered = builtins.foldl' lib.recursiveUpdate perCompilerDerivations toRemove;
-            in filtered;
+            in
+            filtered;
 
           allPkgVersions = chap-meta.chap-package-versions chap-meta.chap-package-meta;
 
@@ -96,13 +98,13 @@
             "cardano-node"
             # from plutus-apps
             "plutus-ledger"
-            ];
+          ];
 
           # using intersectAttrs like this is a cheap way to throw away everything with keys not in
           # smokeTestPackages
           smokeTestPkgVersions =
             builtins.intersectAttrs
-              (lib.genAttrs smokeTestPackages (pkg: {}))
+              (lib.genAttrs smokeTestPackages (pkg: { }))
               (chap-meta.chap-package-latest-versions chap-meta.chap-package-meta);
 
           # use a self + path reference to ensure this runs in the context of the


### PR DESCRIPTION
foliage is now under IOG https://github.com/input-output-hk/foliage, this updates the url in flake.nix and bump its version.