### PR TITLE
Added cardano-api-8.2.0.0

### DIFF
--- a/_sources/cardano-api/8.2.0.0/meta.toml
+++ b/_sources/cardano-api/8.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-25T17:36:19Z
+github = { repo = "input-output-hk/cardano-api", rev = "89fd11781d8ba19ce50f516ecef30607d2e704e8" }
+subdir = 'cardano-api'


### PR DESCRIPTION
Releasing cardano-api-8.2.0.0. This release updates plutus, ledger, and consenus packages. It also provides support for Plutus V3 in the conway ledger era.

From https://github.com/input-output-hk/cardano-api at 89fd11781d8ba19ce50f516ecef30607d2e704e8
