### PR TITLE
Added streaming-0.2.3.1.0.0.0.0.1

### DIFF
--- a/_sources/streaming/0.2.3.1.0.0.0.0.1/meta.toml
+++ b/_sources/streaming/0.2.3.1.0.0.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-05-31T01:47:24Z
+github = { repo = "haskell-streaming/streaming", rev = "0c815bf9043d0f0cbda92b80ef791892e2b7fb43" }
+force-version = true


### PR DESCRIPTION
From https://github.com/haskell-streaming/streaming at 0c815bf9043d0f0cbda92b80ef791892e2b7fb43

Upstream HEAD is fixed, but not yet released to Hackage.
https://github.com/haskell-streaming/streaming/issues/119