### PR TITLE
update network in node

### DIFF
--- a/_sources/cardano-cli/8.1.1/meta.toml
+++ b/_sources/cardano-cli/8.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-06-06T20:41:40Z
+github = { repo = "input-output-hk/cardano-node", rev = "6474e00a0c59109e718d9f62471e1f101d8c3321" }
+subdir = 'cardano-cli'

--- a/_sources/cardano-node/8.1.1/meta.toml
+++ b/_sources/cardano-node/8.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-06-06T20:41:40Z
+github = { repo = "input-output-hk/cardano-node", rev = "6474e00a0c59109e718d9f62471e1f101d8c3321" }
+subdir = 'cardano-node'

--- a/_sources/trace-dispatcher/2.0.0/meta.toml
+++ b/_sources/trace-dispatcher/2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-09T19:32:28Z
 github = { repo = "input-output-hk/cardano-node", rev = "7d1660021b5d627c9a4ed6eb1b473ad471a5e9dd" }
 subdir = 'trace-dispatcher'
+
+[[revisions]]
+number = 1
+timestamp = 2023-06-07T01:24:26Z

--- a/_sources/trace-dispatcher/2.0.0/revisions/1.cabal
+++ b/_sources/trace-dispatcher/2.0.0/revisions/1.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+
+name:                   trace-dispatcher
+version:                2.0.0
+synopsis:               Tracers for Cardano
+description:            Package for development of simple and efficient tracers
+                        based on the arrow based contra-tracer package
+category:               Cardano,
+                        Trace,
+copyright:              2020-2023 Input Output Global Inc (IOG).
+author:                 Juergen Nicklisch-Franken
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+extra-source-files:     CHANGELOG.md
+                        README.md
+                        doc/trace-dispatcher.md
+
+common project-config
+  default-language:     Haskell2010
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Logging
+                      Cardano.Logging.Configuration
+                      Cardano.Logging.ConfigurationParser
+                      Cardano.Logging.DocuGenerator
+                      Cardano.Logging.Formatter
+                      Cardano.Logging.Forwarding
+                      Cardano.Logging.FrequencyLimiter
+                      Cardano.Logging.Trace
+                      Cardano.Logging.TraceDispatcherMessage
+                      Cardano.Logging.Tracer.DataPoint
+                      Cardano.Logging.Tracer.EKG
+                      Cardano.Logging.Tracer.Standard
+                      Cardano.Logging.Tracer.Forward
+                      Cardano.Logging.Tracer.Composed
+                      Cardano.Logging.Types
+                      Cardano.Logging.Utils
+                      Cardano.Logging.Version
+                      Control.Tracer.Arrow
+                      Control.Tracer
+
+  default-extensions:   OverloadedStrings
+  build-depends:        base >=4.12 && <5
+                      , aeson                         >= 2.1.0.0
+                      , async
+                      , bytestring
+                      , cborg
+                      , containers
+                      , contra-tracer
+                      , ekg
+                      , ekg-core
+                      , ekg-forward >= 0.3.0
+                      , hostname
+                      , network
+                      , optparse-applicative-fork
+                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network-api
+                      , ouroboros-network-framework
+                      , serialise
+                      , stm
+                      , text
+                      , time
+                      , trace-forward
+                      , unagi-chan >= 0.4.1.4
+                      , unliftio
+                      , unliftio-core
+                      , unordered-containers
+                      , yaml
+
+  if os(windows)
+     build-depends:     Win32
+  else
+     build-depends:     unix
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-record-updates
+                        -Wpartial-fields
+                        -Widentities
+                        -Wredundant-constraints
+                        -Wmissing-export-lists
+
+executable trace-dispatcher-examples
+  import:               project-config
+  main-is:              Main.hs
+  other-modules:        Examples.TestObjects
+                        Examples.Aggregation
+                        Examples.Trivial
+                        Examples.Routing
+                        Examples.EKG
+                        Examples.Configuration
+                        Examples.DataPoint
+                        Examples.FrequencyLimiting
+                        Examples.Documentation
+  hs-source-dirs:       examples
+  default-extensions:   OverloadedStrings
+  build-depends:        base >=4.12 && <5
+                      , aeson                         >= 2.1.0.0
+                      , bytestring
+                      , containers
+                      , ekg
+                      , ekg-core
+                      , hostname
+                      , stm
+                      , text
+                      , trace-dispatcher
+                      , trace-forward
+                      , time
+                      , unagi-chan >= 0.4.1.4
+                      , unliftio
+                      , unliftio-core
+                      , unordered-containers
+                      , utf8-string
+                      , yaml
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-record-updates
+                        -Wpartial-fields
+                        -Widentities
+                        -Wredundant-constraints
+                        -Wmissing-export-lists
+                        -Wno-incomplete-patterns
+
+test-suite trace-dispatcher-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             trace-dispatcher-test.hs
+  other-modules:       Cardano.Logging.Test.Types
+                       Cardano.Logging.Test.Oracles
+                       Cardano.Logging.Test.Config
+                       Cardano.Logging.Test.Tracer
+                       Cardano.Logging.Test.Script
+
+  default-extensions:   OverloadedStrings
+  build-depends:        base >=4.12 && <5
+                      , aeson                         >= 2.1.0.0
+                      , bytestring
+                      , cardano-prelude
+                      , containers
+                      , ekg
+                      , ekg-core
+                      , generic-data
+                      , hostname
+                      , optparse-applicative
+                      , ouroboros-network ^>= 0.8.1.0
+                      , text
+                      , stm
+                      , tasty
+                      , tasty-quickcheck
+                      , time
+                      , trace-dispatcher
+                      , unagi-chan >= 0.4.1.4
+                      , unliftio
+                      , unliftio-core
+                      , unordered-containers
+                      , yaml
+                      , QuickCheck
+
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-record-updates
+                        -Wpartial-fields
+                        -Widentities
+                        -Wredundant-constraints
+                        -Wmissing-export-lists
+                        -Wno-incomplete-patterns
+
+benchmark trace-dispatcher-bench
+  import:               project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       bench, test
+  main-is:              trace-dispatcher-bench.hs
+  default-extensions:   OverloadedStrings
+  other-modules:        Cardano.Logging.Test.Types
+                        Cardano.Logging.Test.Oracles
+                        Cardano.Logging.Test.Config
+                        Cardano.Logging.Test.Tracer
+                        Cardano.Logging.Test.Script
+  build-depends:        base >=4.12 && <5
+                      , aeson                         >= 2.1.0.0
+                      , containers
+                      , criterion
+                      , ekg
+                      , text
+                      , time
+                      , trace-dispatcher
+                      , QuickCheck

--- a/_sources/trace-dispatcher/2.0.0/revisions/1.cabal
+++ b/_sources/trace-dispatcher/2.0.0/revisions/1.cabal
@@ -56,7 +56,7 @@ library
                       , hostname
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.8.1.0
+                      , ouroboros-network <0.7
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise


### PR DESCRIPTION
`cardano-node` and `cardano-cli` are updated to use `ouroboros-network 8.1.1`, and so have their patch number increased.

The release is using the node release branch `release/8.1.x`.