### PR TITLE
use self-hosted runners for github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,44 +10,25 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  NIX_CONFIG: accept-flake-config = true
+
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: nixos
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # the check script below needs the whole history
 
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: accept-flake-config = true
-
-      - name: Setup nixbuild.net
-        uses: nixbuild/nixbuild-action@v16
-        with:
-          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
-
       - name: Run checks
         run: nix develop -c ./scripts/check.sh
 
   build-repo:
-    runs-on: ubuntu-latest
+    runs-on: nixos
 
     steps:
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: accept-flake-config = true
-
-      - name: Setup nixbuild.net
-        uses: nixbuild/nixbuild-action@v16
-        with:
-          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
-
       - name: Checkout main 
         uses: actions/checkout@v3
         with:
@@ -119,23 +100,11 @@ jobs:
           ./scripts/check-archive-extension.sh _repo-main/01-index.tar _repo/01-index.tar
 
   build-packages:
-    runs-on: ubuntu-latest
+    runs-on: nixos
     needs:
       - build-repo
 
     steps:
-      - name: Install Nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: accept-flake-config = true
-
-      - name: Setup nixbuild.net
-        uses: nixbuild/nixbuild-action@v16
-        with:
-          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
-          generate_summary_for: 'job'
-
       - uses: actions/checkout@v3
 
       - name: Download built repository
@@ -148,37 +117,18 @@ jobs:
         # The > is the "YAML folded string" marker, which replaces 
         # newlines with spaces, since the usual bash idiom of \ 
         # doesn't work for some reason
-        # 
-        # See https://github.com/nixbuild/feedback/issues/14 for
-        # why some of these options are here
         run: >
           nix build .#allSmokeTestPackages
           -L 
           --override-input CHaP path:_repo 
-          --eval-store auto 
-          --store ssh-ng://eu.nixbuild.net 
-          --max-jobs 2
-          --builders ""
           --show-trace
 
   build-new-packages:
-    runs-on: ubuntu-latest
+    runs-on: nixos
     needs:
       - build-repo
 
     steps:
-      - name: Install Nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: accept-flake-config = true
-
-      - name: Setup nixbuild.net
-        uses: nixbuild/nixbuild-action@v16
-        with:
-          nixbuild_token: ${{secrets.NIXBUILD_TOKEN}}
-          generate_summary_for: 'job'
-
       - uses: actions/checkout@v3
 
       - name: Download built repository
@@ -212,14 +162,10 @@ jobs:
           nix build .#allPackages
           -L 
           --override-input CHaP path:_repo 
-          --eval-store auto 
-          --store ssh-ng://eu.nixbuild.net 
-          --max-jobs 2
-          --builders ""
           --show-trace
 
   deploy-check:
-    runs-on: ubuntu-latest
+    runs-on: nixos
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: 
       - build-repo
@@ -249,7 +195,7 @@ jobs:
           ./src/scripts/check-archive-extension.sh repo/01-index.tar built-repo/01-index.tar
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: nixos
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: 
       - check


### PR DESCRIPTION
This also removes nixbuild.net as I guess the point of self-hosted runners is to build ourselves, too. Also their action [writes system-wide SSH config](https://github.com/nixbuild/nixbuild-action/blob/2c22043033fd4118ff8f465d59e1edb7619fca74/nixbuild-action.sh#L123) which is hard to work around.