### PR TITLE
[ci] keep the deploy job on GH Runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,7 +195,8 @@ jobs:
           ./src/scripts/check-archive-extension.sh repo/01-index.tar built-repo/01-index.tar
 
   deploy:
-    runs-on: nixos
+    # This job is fine to run on GitHub provided (free) runners.
+    runs-on: ubunutu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: 
       - check


### PR DESCRIPTION
This was broken in #335, there is no need to run the deploy job on our self-hosted runners as far as I can see.