### PR TITLE
Release 8.2 cardano-ledger packages (second wave)

### DIFF
--- a/_sources/byron-spec-chain/1.0.0.1/meta.toml
+++ b/_sources/byron-spec-chain/1.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/1.0.0.1/meta.toml
+++ b/_sources/byron-spec-ledger/1.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-ledger-allegra/1.2.0.2/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.2.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo-test/1.1.2.2/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/1.1.2.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/1.3.1.1/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.3.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage-test/1.1.1.3/meta.toml
+++ b/_sources/cardano-ledger-babbage-test/1.1.1.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/babbage/test-suite'

--- a/_sources/cardano-ledger-babbage/1.4.0.1/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.4.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-byron/1.0.0.2/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/byron/ledger/impl'

--- a/_sources/cardano-ledger-conway-test/1.2.0.2/meta.toml
+++ b/_sources/cardano-ledger-conway-test/1.2.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/conway/test-suite'

--- a/_sources/cardano-ledger-conway/1.5.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-mary/1.3.0.2/meta.toml
+++ b/_sources/cardano-ledger-mary/1.3.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-pretty/1.2.1.1/meta.toml
+++ b/_sources/cardano-ledger-pretty/1.2.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'libs/cardano-ledger-pretty'

--- a/_sources/cardano-ledger-shelley/1.4.1.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.4.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.0.3.3/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.0.3.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-05T12:27:25Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
+subdir = 'libs/cardano-protocol-tpraos'


### PR DESCRIPTION
- Added `cardano-ledger-pretty-1.2.1.1`
- Added `cardano-ledger-core-1.4.0.0`
- Added `cardano-ledger-api-1.3.0.0`
- Added `cardano-ledger-shelley-1.4.1.0`
- Added `cardano-ledger-mary-1.3.0.2`
- Added `cardano-ledger-conway-1.5.0.0`
- Added `cardano-ledger-byron-1.0.0.2`
- Added `byron-spec-ledger-1.0.0.1`
- Added `byron-spec-chain-1.0.0.1`
- Added `cardano-ledger-babbage-1.4.0.1`

I'm not certain that this is the full set of changes required from cardano-ledger, but this includes all of the packages whose versions have been incremented. There are some other changes to dependency bounds, though I'm not certain that this warrants the affected packages being released.