### PR TITLE
release cardano-api and cardano-cli

### DIFF
--- a/_sources/cardano-api/8.8.0.0/meta.toml
+++ b/_sources/cardano-api/8.8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-07T16:55:19Z
+github = { repo = "input-output-hk/cardano-api", rev = "511ea889d439e02a5c084418b44a4ddacf32686f" }
+subdir = 'cardano-api'

--- a/_sources/cardano-cli/8.2.2/meta.toml
+++ b/_sources/cardano-cli/8.2.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-07T17:06:02Z
+github = { repo = "input-output-hk/cardano-cli", rev = "d3b7f7e92c686c39357f8b4e4d98b6689d3f5d7e" }
+subdir = 'cardano-cli'


### PR DESCRIPTION
From https://github.com/input-output-hk/cardano-api at 511ea889d439e02a5c084418b44a4ddacf32686f<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
