### PR TITLE
Backport mint translation bugfix

### DIFF
--- a/_sources/cardano-ledger-alonzo/1.3.3.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.3.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-24T10:12:33Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6611db40a1f6fb297c49f9e0aeffd87b224106e8" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-babbage/1.4.2.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.4.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-07-24T10:12:33Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "6611db40a1f6fb297c49f9e0aeffd87b224106e8" }
+subdir = 'eras/babbage/impl'


### PR DESCRIPTION
This PR makes a release of
* cardano-ledger-alonzo-1.3.3.0
* cardano-ledger-babbage-1.4.2.0

Which contains a backport of a fix implemented in https://github.com/input-output-hk/cardano-ledger/pull/3567