### PR TITLE
`fs-sim-0.2.1.0`, `fs-api-0.2.0.0`, accompanying `ouroboros-consensus` revisions

### DIFF
--- a/_sources/fs-api/0.2.0.0/meta.toml
+++ b/_sources/fs-api/0.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-01T16:16:49Z
+github = { repo = "input-output-hk/fs-sim", rev = "f4a471dd5eb5598530c03d76acb040ce456cd338" }
+subdir = 'fs-api'

--- a/_sources/fs-sim/0.2.1.0/meta.toml
+++ b/_sources/fs-sim/0.2.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-01T16:16:59Z
+github = { repo = "input-output-hk/fs-sim", rev = "8ce77e135e6a6c16923d84e2abc4dbe02948a5de" }
+subdir = 'fs-sim'

--- a/_sources/ouroboros-consensus/0.7.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.7.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-24T10:40:16Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "143e9df61aee2f00657bee3cfe4b7b3140c853a1" }
 subdir = 'ouroboros-consensus'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-01T13:04:51Z

--- a/_sources/ouroboros-consensus/0.7.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus/0.7.0.0/revisions/1.cabal
@@ -1,0 +1,669 @@
+cabal-version:   3.0
+name:            ouroboros-consensus
+version:         0.7.0.0
+synopsis:        Consensus layer for the Ouroboros blockchain protocol
+description:     Consensus layer for the Ouroboros blockchain protocol.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:           common-lib
+  hs-source-dirs:   src/ouroboros-consensus
+  exposed-modules:
+    Data.SOP.Counting
+    Data.SOP.Functors
+    Data.SOP.Index
+    Data.SOP.InPairs
+    Data.SOP.Lenses
+    Data.SOP.Match
+    Data.SOP.NonEmpty
+    Data.SOP.OptNP
+    Data.SOP.Strict
+    Data.SOP.Tails
+    Data.SOP.Telescope
+    Ouroboros.Consensus.Block
+    Ouroboros.Consensus.Block.Abstract
+    Ouroboros.Consensus.Block.EBB
+    Ouroboros.Consensus.Block.Forging
+    Ouroboros.Consensus.Block.NestedContent
+    Ouroboros.Consensus.Block.RealPoint
+    Ouroboros.Consensus.Block.SupportsMetrics
+    Ouroboros.Consensus.Block.SupportsProtocol
+    Ouroboros.Consensus.BlockchainTime
+    Ouroboros.Consensus.BlockchainTime.API
+    Ouroboros.Consensus.BlockchainTime.WallClock.Default
+    Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+    Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+    Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Config
+    Ouroboros.Consensus.Config.SecurityParam
+    Ouroboros.Consensus.Config.SupportsNode
+    Ouroboros.Consensus.Forecast
+    Ouroboros.Consensus.Fragment.Diff
+    Ouroboros.Consensus.Fragment.InFuture
+    Ouroboros.Consensus.Fragment.Validated
+    Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.HardFork.Abstract
+    Ouroboros.Consensus.HardFork.Combinator
+    Ouroboros.Consensus.HardFork.Combinator.Abstract
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+    Ouroboros.Consensus.HardFork.Combinator.Basics
+    Ouroboros.Consensus.HardFork.Combinator.Block
+    Ouroboros.Consensus.HardFork.Combinator.Compat
+    Ouroboros.Consensus.HardFork.Combinator.Condense
+    Ouroboros.Consensus.HardFork.Combinator.Degenerate
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+    Ouroboros.Consensus.HardFork.Combinator.Forging
+    Ouroboros.Consensus.HardFork.Combinator.Info
+    Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+    Ouroboros.Consensus.HardFork.Combinator.Ledger
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    Ouroboros.Consensus.HardFork.Combinator.Lifting
+    Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.Node
+    Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+    Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+    Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+    Ouroboros.Consensus.HardFork.Combinator.Protocol
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+    Ouroboros.Consensus.HardFork.Combinator.State
+    Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    Ouroboros.Consensus.HardFork.Combinator.State.Instances
+    Ouroboros.Consensus.HardFork.Combinator.State.Lift
+    Ouroboros.Consensus.HardFork.Combinator.State.Types
+    Ouroboros.Consensus.HardFork.Combinator.Translation
+    Ouroboros.Consensus.HardFork.History
+    Ouroboros.Consensus.HardFork.History.Caching
+    Ouroboros.Consensus.HardFork.History.EpochInfo
+    Ouroboros.Consensus.HardFork.History.EraParams
+    Ouroboros.Consensus.HardFork.History.Qry
+    Ouroboros.Consensus.HardFork.History.Summary
+    Ouroboros.Consensus.HardFork.History.Util
+    Ouroboros.Consensus.HardFork.Simple
+    Ouroboros.Consensus.HeaderStateHistory
+    Ouroboros.Consensus.HeaderValidation
+    Ouroboros.Consensus.Ledger.Abstract
+    Ouroboros.Consensus.Ledger.Basics
+    Ouroboros.Consensus.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.Ledger.Dual
+    Ouroboros.Consensus.Ledger.Extended
+    Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Query
+    Ouroboros.Consensus.Ledger.Query.Version
+    Ouroboros.Consensus.Ledger.SupportsMempool
+    Ouroboros.Consensus.Ledger.SupportsPeerSelection
+    Ouroboros.Consensus.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Mempool
+    Ouroboros.Consensus.Mempool.API
+    Ouroboros.Consensus.Mempool.Capacity
+    Ouroboros.Consensus.Mempool.Impl.Common
+    Ouroboros.Consensus.Mempool.Init
+    Ouroboros.Consensus.Mempool.Query
+    Ouroboros.Consensus.Mempool.TxSeq
+    Ouroboros.Consensus.Mempool.Update
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+    Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.InitStorage
+    Ouroboros.Consensus.Node.NetworkProtocolVersion
+    Ouroboros.Consensus.Node.ProtocolInfo
+    Ouroboros.Consensus.Node.Run
+    Ouroboros.Consensus.Node.Serialisation
+    Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Protocol.Abstract
+    Ouroboros.Consensus.Protocol.BFT
+    Ouroboros.Consensus.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Protocol.MockChainSel
+    Ouroboros.Consensus.Protocol.ModChainSel
+    Ouroboros.Consensus.Protocol.PBFT
+    Ouroboros.Consensus.Protocol.PBFT.Crypto
+    Ouroboros.Consensus.Protocol.PBFT.State
+    Ouroboros.Consensus.Protocol.Signed
+    Ouroboros.Consensus.Storage.ChainDB
+    Ouroboros.Consensus.Storage.ChainDB.API
+    Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+    Ouroboros.Consensus.Storage.ChainDB.Impl
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+    Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
+    Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Query
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+    Ouroboros.Consensus.Storage.ChainDB.Init
+    Ouroboros.Consensus.Storage.Common
+    Ouroboros.Consensus.Storage.ImmutableDB
+    Ouroboros.Consensus.Storage.ImmutableDB.API
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
+    Ouroboros.Consensus.Storage.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+    Ouroboros.Consensus.Storage.LedgerDB.Init
+    Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.Query
+    Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+    Ouroboros.Consensus.Storage.LedgerDB.Stream
+    Ouroboros.Consensus.Storage.LedgerDB.Update
+    Ouroboros.Consensus.Storage.Serialisation
+    Ouroboros.Consensus.Storage.VolatileDB
+    Ouroboros.Consensus.Storage.VolatileDB.API
+    Ouroboros.Consensus.Storage.VolatileDB.Impl
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
+    Ouroboros.Consensus.Ticked
+    Ouroboros.Consensus.TypeFamilyWrappers
+    Ouroboros.Consensus.Util
+    Ouroboros.Consensus.Util.AnchoredFragment
+    Ouroboros.Consensus.Util.Args
+    Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.CallStack
+    Ouroboros.Consensus.Util.CBOR
+    Ouroboros.Consensus.Util.Condense
+    Ouroboros.Consensus.Util.DepPair
+    Ouroboros.Consensus.Util.EarlyExit
+    Ouroboros.Consensus.Util.Enclose
+    Ouroboros.Consensus.Util.FileLock
+    Ouroboros.Consensus.Util.HList
+    Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.MonadSTM.NormalForm
+    Ouroboros.Consensus.Util.MonadSTM.RAWLock
+    Ouroboros.Consensus.Util.MonadSTM.StrictMVar
+    Ouroboros.Consensus.Util.Orphans
+    Ouroboros.Consensus.Util.RedundantConstraints
+    Ouroboros.Consensus.Util.ResourceRegistry
+    Ouroboros.Consensus.Util.Singletons
+    Ouroboros.Consensus.Util.STM
+    Ouroboros.Consensus.Util.TentativeState
+    Ouroboros.Consensus.Util.Time
+    Ouroboros.Consensus.Util.TraceSize
+    Ouroboros.Consensus.Util.Versioned
+
+  other-extensions:
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveFunctor
+    DeriveGeneric
+    EmptyDataDecls
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NamedFieldPuns
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeInType
+    TypeOperators
+    UndecidableInstances
+    UndecidableSuperClasses
+    ViewPatterns
+
+  build-depends:
+    , base                         >=4.14     && <4.17
+    , base16-bytestring
+    , bimap                        >=0.4      && <0.5
+    , binary                       >=0.8      && <0.11
+    , bytestring                   >=0.10     && <0.12
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-binary
+    , cardano-prelude
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                        >=0.2.2    && <0.3
+    , containers                   >=0.5      && <0.7
+    , contra-tracer
+    , deepseq
+    , filelock
+    , fs-api                       ^>=0.1
+    , hashable
+    , io-classes                   ^>=1.1
+    , measures
+    , mtl                          >=2.2      && <2.3
+    , nothunks                     >=0.1.2    && <0.2
+    , ouroboros-network-api        ^>=0.5
+    , ouroboros-network-framework  ^>=0.6
+    , ouroboros-network-mock       ^>=0.1.0.1
+    , ouroboros-network-protocols  ^>=0.5
+    , psqueues                     >=0.2.3    && <0.3
+    , quiet                        >=0.2      && <0.3
+    , semialign                    >=1.1
+    , serialise                    >=0.2      && <0.3
+    , si-timers                    ^>=1.1
+    , sop-core                     >=0.5      && <0.6
+    , streaming
+    , strict-stm                   ^>=1.1
+    , text                         >=1.2      && <1.3
+    , these                        >=1.1      && <1.2
+    , time
+    , transformers
+    , typed-protocols
+    , vector                       >=0.12     && <0.13
+
+library consensus-testlib
+  import:          common-lib
+  hs-source-dirs:  src/consensus-testlib
+  visibility:      public
+  exposed-modules:
+    Test.Util.BoolProps
+    Test.Util.ChainDB
+    Test.Util.ChainUpdates
+    Test.Util.ChunkInfo
+    Test.Util.Corruption
+    Test.Util.FileLock
+    Test.Util.HardFork.Future
+    Test.Util.HardFork.OracularClock
+    Test.Util.InvertedMap
+    Test.Util.LogicalClock
+    Test.Util.MockChain
+    Test.Util.Orphans.Arbitrary
+    Test.Util.Orphans.IOLike
+    Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.SignableRepresentation
+    Test.Util.Orphans.ToExpr
+    Test.Util.Paths
+    Test.Util.QSM
+    Test.Util.QuickCheck
+    Test.Util.Range
+    Test.Util.RefEnv
+    Test.Util.Schedule
+    Test.Util.Serialisation.Golden
+    Test.Util.Serialisation.Roundtrip
+    Test.Util.Shrink
+    Test.Util.Slots
+    Test.Util.SOP
+    Test.Util.Split
+    Test.Util.Stream
+    Test.Util.TestBlock
+    Test.Util.TestEnv
+    Test.Util.Time
+    Test.Util.Tracer
+    Test.Util.WithEq
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-prelude
+    , cardano-strict-containers
+    , cborg
+    , containers
+    , contra-tracer
+    , deepseq
+    , directory
+    , file-embed
+    , filepath
+    , fs-api                                                  ^>=0.1
+    , fs-sim                                                  ^>=0.2
+    , generics-sop
+    , io-sim
+    , mtl
+    , nothunks
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , QuickCheck
+    , quickcheck-state-machine
+    , quiet
+    , random
+    , serialise
+    , sop-core
+    , tasty
+    , tasty-golden
+    , tasty-quickcheck
+    , template-haskell
+    , time
+    , tree-diff
+    , utf8-string
+
+library mock-block
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/mock-block
+  exposed-modules:
+    Ouroboros.Consensus.Mock.Ledger
+    Ouroboros.Consensus.Mock.Ledger.Address
+    Ouroboros.Consensus.Mock.Ledger.Block
+    Ouroboros.Consensus.Mock.Ledger.Block.BFT
+    Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+    Ouroboros.Consensus.Mock.Ledger.Block.Praos
+    Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+    Ouroboros.Consensus.Mock.Ledger.Forge
+    Ouroboros.Consensus.Mock.Ledger.Stake
+    Ouroboros.Consensus.Mock.Ledger.State
+    Ouroboros.Consensus.Mock.Ledger.UTxO
+    Ouroboros.Consensus.Mock.Node
+    Ouroboros.Consensus.Mock.Node.Abstract
+    Ouroboros.Consensus.Mock.Node.BFT
+    Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Praos
+    Ouroboros.Consensus.Mock.Node.PraosRule
+    Ouroboros.Consensus.Mock.Node.Serialisation
+    Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Mock.Protocol.Praos
+
+  build-depends:
+    , base
+    , bimap
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , deepseq
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , serialise
+    , time
+
+library tutorials
+  import:         common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs: src/tutorials
+  other-modules:
+    Ouroboros.Consensus.Tutorial.Simple
+    Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:
+    , base
+    , containers
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , serialise
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.HardFork.Forecast
+    Test.Consensus.HardFork.History
+    Test.Consensus.HardFork.Infra
+    Test.Consensus.HardFork.Summary
+    Test.Consensus.Mempool
+    Test.Consensus.Mempool.Fairness
+    Test.Consensus.Mempool.Fairness.TestBlock
+    Test.Consensus.MiniProtocol.BlockFetch.Client
+    Test.Consensus.MiniProtocol.ChainSync.Client
+    Test.Consensus.MiniProtocol.LocalStateQuery.Server
+    Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.RAWLock
+    Test.Consensus.Util.Versioned
+
+  build-depends:
+    , async
+    , base
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , fs-api                                                              ^>=0.1
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mock-block
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-mock
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , QuickCheck
+    , quickcheck-state-machine
+    , random
+    , serialise
+    , si-timers
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , time
+    , tree-diff
+    , typed-protocols
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:
+    Ouroboros.Consensus.Util.Tests
+    Test.Util.ChainUpdates.Tests
+    Test.Util.Schedule.Tests
+    Test.Util.Split.Tests
+
+  build-depends:
+    , base
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , tasty
+    , tasty-quickcheck
+
+test-suite storage-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/storage-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Ouroboros.Storage
+    Test.Ouroboros.Storage.ChainDB
+    Test.Ouroboros.Storage.ChainDB.FollowerPromptness
+    Test.Ouroboros.Storage.ChainDB.GcSchedule
+    Test.Ouroboros.Storage.ChainDB.Iterator
+    Test.Ouroboros.Storage.ChainDB.Model
+    Test.Ouroboros.Storage.ChainDB.Model.Test
+    Test.Ouroboros.Storage.ChainDB.Paths
+    Test.Ouroboros.Storage.ChainDB.StateMachine
+    Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl
+    Test.Ouroboros.Storage.ChainDB.Unit
+    Test.Ouroboros.Storage.ImmutableDB
+    Test.Ouroboros.Storage.ImmutableDB.Mock
+    Test.Ouroboros.Storage.ImmutableDB.Model
+    Test.Ouroboros.Storage.ImmutableDB.Primary
+    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    Test.Ouroboros.Storage.LedgerDB
+    Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+    Test.Ouroboros.Storage.LedgerDB.InMemory
+    Test.Ouroboros.Storage.LedgerDB.OnDisk
+    Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
+    Test.Ouroboros.Storage.Orphans
+    Test.Ouroboros.Storage.TestBlock
+    Test.Ouroboros.Storage.VolatileDB
+    Test.Ouroboros.Storage.VolatileDB.Mock
+    Test.Ouroboros.Storage.VolatileDB.Model
+    Test.Ouroboros.Storage.VolatileDB.StateMachine
+
+  build-depends:
+    , base
+    , bifunctors
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , fs-api                    ^>=0.1
+    , fs-sim                    ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  >=0.7.0 && <0.7.1
+    , random
+    , serialise
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , time
+    , tree-diff
+    , vector
+
+benchmark mempool-bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench/mempool-bench
+  main-is:          Main.hs
+  other-modules:
+    Bench.Consensus.Mempool
+    Bench.Consensus.Mempool.TestBlock
+    Bench.Consensus.MempoolWithMockedLedgerItf
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-slotting
+    , cassava
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , nothunks
+    , ouroboros-consensus
+    , serialise
+    , strict-stm
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , text
+    , transformers
+    , tree-diff
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64

--- a/_sources/ouroboros-consensus/0.8.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.8.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-06-23T14:07:51Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "f40712ff376b8ee65d1d3f14f285c008ea22a634" }
 subdir = 'ouroboros-consensus'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-01T13:04:52Z

--- a/_sources/ouroboros-consensus/0.8.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus/0.8.0.0/revisions/1.cabal
@@ -1,0 +1,668 @@
+cabal-version:   3.0
+name:            ouroboros-consensus
+version:         0.8.0.0
+synopsis:        Consensus layer for the Ouroboros blockchain protocol
+description:     Consensus layer for the Ouroboros blockchain protocol.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:           common-lib
+  hs-source-dirs:   src/ouroboros-consensus
+  exposed-modules:
+    Data.SOP.Counting
+    Data.SOP.Functors
+    Data.SOP.Index
+    Data.SOP.InPairs
+    Data.SOP.Lenses
+    Data.SOP.Match
+    Data.SOP.NonEmpty
+    Data.SOP.OptNP
+    Data.SOP.Strict
+    Data.SOP.Tails
+    Data.SOP.Telescope
+    Ouroboros.Consensus.Block
+    Ouroboros.Consensus.Block.Abstract
+    Ouroboros.Consensus.Block.EBB
+    Ouroboros.Consensus.Block.Forging
+    Ouroboros.Consensus.Block.NestedContent
+    Ouroboros.Consensus.Block.RealPoint
+    Ouroboros.Consensus.Block.SupportsMetrics
+    Ouroboros.Consensus.Block.SupportsProtocol
+    Ouroboros.Consensus.BlockchainTime
+    Ouroboros.Consensus.BlockchainTime.API
+    Ouroboros.Consensus.BlockchainTime.WallClock.Default
+    Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+    Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+    Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Config
+    Ouroboros.Consensus.Config.SecurityParam
+    Ouroboros.Consensus.Config.SupportsNode
+    Ouroboros.Consensus.Forecast
+    Ouroboros.Consensus.Fragment.Diff
+    Ouroboros.Consensus.Fragment.InFuture
+    Ouroboros.Consensus.Fragment.Validated
+    Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.HardFork.Abstract
+    Ouroboros.Consensus.HardFork.Combinator
+    Ouroboros.Consensus.HardFork.Combinator.Abstract
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+    Ouroboros.Consensus.HardFork.Combinator.Basics
+    Ouroboros.Consensus.HardFork.Combinator.Block
+    Ouroboros.Consensus.HardFork.Combinator.Compat
+    Ouroboros.Consensus.HardFork.Combinator.Condense
+    Ouroboros.Consensus.HardFork.Combinator.Degenerate
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+    Ouroboros.Consensus.HardFork.Combinator.Forging
+    Ouroboros.Consensus.HardFork.Combinator.Info
+    Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+    Ouroboros.Consensus.HardFork.Combinator.Ledger
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    Ouroboros.Consensus.HardFork.Combinator.Lifting
+    Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.Node
+    Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+    Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+    Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+    Ouroboros.Consensus.HardFork.Combinator.Protocol
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+    Ouroboros.Consensus.HardFork.Combinator.State
+    Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    Ouroboros.Consensus.HardFork.Combinator.State.Instances
+    Ouroboros.Consensus.HardFork.Combinator.State.Lift
+    Ouroboros.Consensus.HardFork.Combinator.State.Types
+    Ouroboros.Consensus.HardFork.Combinator.Translation
+    Ouroboros.Consensus.HardFork.History
+    Ouroboros.Consensus.HardFork.History.Caching
+    Ouroboros.Consensus.HardFork.History.EpochInfo
+    Ouroboros.Consensus.HardFork.History.EraParams
+    Ouroboros.Consensus.HardFork.History.Qry
+    Ouroboros.Consensus.HardFork.History.Summary
+    Ouroboros.Consensus.HardFork.History.Util
+    Ouroboros.Consensus.HardFork.Simple
+    Ouroboros.Consensus.HeaderStateHistory
+    Ouroboros.Consensus.HeaderValidation
+    Ouroboros.Consensus.Ledger.Abstract
+    Ouroboros.Consensus.Ledger.Basics
+    Ouroboros.Consensus.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.Ledger.Dual
+    Ouroboros.Consensus.Ledger.Extended
+    Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Query
+    Ouroboros.Consensus.Ledger.Query.Version
+    Ouroboros.Consensus.Ledger.SupportsMempool
+    Ouroboros.Consensus.Ledger.SupportsPeerSelection
+    Ouroboros.Consensus.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Mempool
+    Ouroboros.Consensus.Mempool.API
+    Ouroboros.Consensus.Mempool.Capacity
+    Ouroboros.Consensus.Mempool.Impl.Common
+    Ouroboros.Consensus.Mempool.Init
+    Ouroboros.Consensus.Mempool.Query
+    Ouroboros.Consensus.Mempool.TxSeq
+    Ouroboros.Consensus.Mempool.Update
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+    Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.InitStorage
+    Ouroboros.Consensus.Node.NetworkProtocolVersion
+    Ouroboros.Consensus.Node.ProtocolInfo
+    Ouroboros.Consensus.Node.Run
+    Ouroboros.Consensus.Node.Serialisation
+    Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Protocol.Abstract
+    Ouroboros.Consensus.Protocol.BFT
+    Ouroboros.Consensus.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Protocol.MockChainSel
+    Ouroboros.Consensus.Protocol.ModChainSel
+    Ouroboros.Consensus.Protocol.PBFT
+    Ouroboros.Consensus.Protocol.PBFT.Crypto
+    Ouroboros.Consensus.Protocol.PBFT.State
+    Ouroboros.Consensus.Protocol.Signed
+    Ouroboros.Consensus.Storage.ChainDB
+    Ouroboros.Consensus.Storage.ChainDB.API
+    Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+    Ouroboros.Consensus.Storage.ChainDB.Impl
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+    Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
+    Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Query
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+    Ouroboros.Consensus.Storage.ChainDB.Init
+    Ouroboros.Consensus.Storage.Common
+    Ouroboros.Consensus.Storage.ImmutableDB
+    Ouroboros.Consensus.Storage.ImmutableDB.API
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
+    Ouroboros.Consensus.Storage.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+    Ouroboros.Consensus.Storage.LedgerDB.Init
+    Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.Query
+    Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+    Ouroboros.Consensus.Storage.LedgerDB.Stream
+    Ouroboros.Consensus.Storage.LedgerDB.Update
+    Ouroboros.Consensus.Storage.Serialisation
+    Ouroboros.Consensus.Storage.VolatileDB
+    Ouroboros.Consensus.Storage.VolatileDB.API
+    Ouroboros.Consensus.Storage.VolatileDB.Impl
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
+    Ouroboros.Consensus.Ticked
+    Ouroboros.Consensus.TypeFamilyWrappers
+    Ouroboros.Consensus.Util
+    Ouroboros.Consensus.Util.AnchoredFragment
+    Ouroboros.Consensus.Util.Args
+    Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.CallStack
+    Ouroboros.Consensus.Util.CBOR
+    Ouroboros.Consensus.Util.Condense
+    Ouroboros.Consensus.Util.DepPair
+    Ouroboros.Consensus.Util.EarlyExit
+    Ouroboros.Consensus.Util.Enclose
+    Ouroboros.Consensus.Util.FileLock
+    Ouroboros.Consensus.Util.HList
+    Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.MonadSTM.NormalForm
+    Ouroboros.Consensus.Util.MonadSTM.RAWLock
+    Ouroboros.Consensus.Util.MonadSTM.StrictSVar
+    Ouroboros.Consensus.Util.Orphans
+    Ouroboros.Consensus.Util.RedundantConstraints
+    Ouroboros.Consensus.Util.ResourceRegistry
+    Ouroboros.Consensus.Util.Singletons
+    Ouroboros.Consensus.Util.STM
+    Ouroboros.Consensus.Util.TentativeState
+    Ouroboros.Consensus.Util.Time
+    Ouroboros.Consensus.Util.TraceSize
+    Ouroboros.Consensus.Util.Versioned
+
+  other-extensions:
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveFunctor
+    DeriveGeneric
+    EmptyDataDecls
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NamedFieldPuns
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeInType
+    TypeOperators
+    UndecidableInstances
+    UndecidableSuperClasses
+    ViewPatterns
+
+  build-depends:
+    , base                         >=4.14     && <4.17
+    , base16-bytestring
+    , bimap                        >=0.4      && <0.5
+    , binary                       >=0.8      && <0.11
+    , bytestring                   >=0.10     && <0.12
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-prelude
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                        >=0.2.2    && <0.3
+    , containers                   >=0.5      && <0.7
+    , contra-tracer
+    , deepseq
+    , filelock
+    , fs-api                       ^>=0.1
+    , hashable
+    , io-classes                   ^>=1.1
+    , measures
+    , mtl                          >=2.2      && <2.3
+    , nothunks                     >=0.1.2    && <0.2
+    , ouroboros-network-api        ^>=0.5
+    , ouroboros-network-mock       ^>=0.1.0.1
+    , ouroboros-network-protocols  ^>=0.5
+    , psqueues                     >=0.2.3    && <0.3
+    , quiet                        >=0.2      && <0.3
+    , semialign                    >=1.1
+    , serialise                    >=0.2      && <0.3
+    , si-timers                    ^>=1.1
+    , sop-core                     >=0.5      && <0.6
+    , streaming
+    , strict-stm                   ^>=1.1
+    , text                         >=1.2      && <1.3
+    , these                        >=1.1      && <1.2
+    , time
+    , transformers
+    , typed-protocols
+    , vector                       >=0.12     && <0.13
+
+library consensus-testlib
+  import:          common-lib
+  hs-source-dirs:  src/consensus-testlib
+  visibility:      public
+  exposed-modules:
+    Test.Util.BoolProps
+    Test.Util.ChainDB
+    Test.Util.ChainUpdates
+    Test.Util.ChunkInfo
+    Test.Util.Corruption
+    Test.Util.FileLock
+    Test.Util.HardFork.Future
+    Test.Util.HardFork.OracularClock
+    Test.Util.InvertedMap
+    Test.Util.LogicalClock
+    Test.Util.MockChain
+    Test.Util.Orphans.Arbitrary
+    Test.Util.Orphans.IOLike
+    Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.SignableRepresentation
+    Test.Util.Orphans.ToExpr
+    Test.Util.Paths
+    Test.Util.QSM
+    Test.Util.QuickCheck
+    Test.Util.Range
+    Test.Util.RefEnv
+    Test.Util.Schedule
+    Test.Util.Serialisation.Golden
+    Test.Util.Serialisation.Roundtrip
+    Test.Util.Shrink
+    Test.Util.Slots
+    Test.Util.SOP
+    Test.Util.Split
+    Test.Util.Stream
+    Test.Util.TestBlock
+    Test.Util.TestEnv
+    Test.Util.Time
+    Test.Util.Tracer
+    Test.Util.WithEq
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-prelude
+    , cardano-strict-containers
+    , cborg
+    , containers
+    , contra-tracer
+    , deepseq
+    , directory
+    , file-embed
+    , filepath
+    , fs-api                                                  ^>=0.1
+    , fs-sim                                                  ^>=0.2
+    , generics-sop
+    , io-sim
+    , mtl
+    , nothunks
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , QuickCheck
+    , quickcheck-state-machine
+    , quiet
+    , random
+    , serialise
+    , sop-core
+    , tasty
+    , tasty-golden
+    , tasty-quickcheck
+    , template-haskell
+    , time
+    , tree-diff
+    , utf8-string
+
+library mock-block
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/mock-block
+  exposed-modules:
+    Ouroboros.Consensus.Mock.Ledger
+    Ouroboros.Consensus.Mock.Ledger.Address
+    Ouroboros.Consensus.Mock.Ledger.Block
+    Ouroboros.Consensus.Mock.Ledger.Block.BFT
+    Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+    Ouroboros.Consensus.Mock.Ledger.Block.Praos
+    Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+    Ouroboros.Consensus.Mock.Ledger.Forge
+    Ouroboros.Consensus.Mock.Ledger.Stake
+    Ouroboros.Consensus.Mock.Ledger.State
+    Ouroboros.Consensus.Mock.Ledger.UTxO
+    Ouroboros.Consensus.Mock.Node
+    Ouroboros.Consensus.Mock.Node.Abstract
+    Ouroboros.Consensus.Mock.Node.BFT
+    Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Praos
+    Ouroboros.Consensus.Mock.Node.PraosRule
+    Ouroboros.Consensus.Mock.Node.Serialisation
+    Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Mock.Protocol.Praos
+
+  build-depends:
+    , base
+    , bimap
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , deepseq
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , serialise
+    , time
+
+library tutorials
+  import:         common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs: src/tutorials
+  other-modules:
+    Ouroboros.Consensus.Tutorial.Simple
+    Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:
+    , base
+    , containers
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , serialise
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.HardFork.Forecast
+    Test.Consensus.HardFork.History
+    Test.Consensus.HardFork.Infra
+    Test.Consensus.HardFork.Summary
+    Test.Consensus.Mempool
+    Test.Consensus.Mempool.Fairness
+    Test.Consensus.Mempool.Fairness.TestBlock
+    Test.Consensus.MiniProtocol.BlockFetch.Client
+    Test.Consensus.MiniProtocol.ChainSync.Client
+    Test.Consensus.MiniProtocol.LocalStateQuery.Server
+    Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.NormalForm
+    Test.Consensus.Util.MonadSTM.RAWLock
+    Test.Consensus.Util.Versioned
+
+  build-depends:
+    , async
+    , base
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , fs-api                                                              ^>=0.1
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mock-block
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , QuickCheck
+    , quickcheck-state-machine
+    , random
+    , serialise
+    , si-timers
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , time
+    , tree-diff
+    , typed-protocols
+    , typed-protocols-examples
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:
+    Ouroboros.Consensus.Util.Tests
+    Test.Util.ChainUpdates.Tests
+    Test.Util.Schedule.Tests
+    Test.Util.Split.Tests
+
+  build-depends:
+    , base
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , tasty
+    , tasty-quickcheck
+
+test-suite storage-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/storage-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Ouroboros.Storage
+    Test.Ouroboros.Storage.ChainDB
+    Test.Ouroboros.Storage.ChainDB.FollowerPromptness
+    Test.Ouroboros.Storage.ChainDB.GcSchedule
+    Test.Ouroboros.Storage.ChainDB.Iterator
+    Test.Ouroboros.Storage.ChainDB.Model
+    Test.Ouroboros.Storage.ChainDB.Model.Test
+    Test.Ouroboros.Storage.ChainDB.Paths
+    Test.Ouroboros.Storage.ChainDB.StateMachine
+    Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl
+    Test.Ouroboros.Storage.ChainDB.Unit
+    Test.Ouroboros.Storage.ImmutableDB
+    Test.Ouroboros.Storage.ImmutableDB.Mock
+    Test.Ouroboros.Storage.ImmutableDB.Model
+    Test.Ouroboros.Storage.ImmutableDB.Primary
+    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    Test.Ouroboros.Storage.LedgerDB
+    Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+    Test.Ouroboros.Storage.LedgerDB.InMemory
+    Test.Ouroboros.Storage.LedgerDB.OnDisk
+    Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
+    Test.Ouroboros.Storage.Orphans
+    Test.Ouroboros.Storage.TestBlock
+    Test.Ouroboros.Storage.VolatileDB
+    Test.Ouroboros.Storage.VolatileDB.Mock
+    Test.Ouroboros.Storage.VolatileDB.Model
+    Test.Ouroboros.Storage.VolatileDB.StateMachine
+
+  build-depends:
+    , base
+    , bifunctors
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , fs-api                    ^>=0.1
+    , fs-sim                    ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  >=0.7.0 && <0.7.1
+    , random
+    , serialise
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , time
+    , tree-diff
+    , vector
+
+benchmark mempool-bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench/mempool-bench
+  main-is:          Main.hs
+  other-modules:
+    Bench.Consensus.Mempool
+    Bench.Consensus.Mempool.TestBlock
+    Bench.Consensus.MempoolWithMockedLedgerItf
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-slotting
+    , cassava
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , nothunks
+    , ouroboros-consensus
+    , serialise
+    , strict-stm
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , text
+    , transformers
+    , tree-diff
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64

--- a/_sources/ouroboros-consensus/0.9.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.9.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-07-06T12:33:34Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "c50490f52ef8c8093b92a9a0f0a14d8c3e5eaf12" }
 subdir = 'ouroboros-consensus'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-01T13:04:53Z

--- a/_sources/ouroboros-consensus/0.9.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus/0.9.0.0/revisions/1.cabal
@@ -1,0 +1,669 @@
+cabal-version:   3.0
+name:            ouroboros-consensus
+version:         0.9.0.0
+synopsis:        Consensus layer for the Ouroboros blockchain protocol
+description:     Consensus layer for the Ouroboros blockchain protocol.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:           common-lib
+  hs-source-dirs:   src/ouroboros-consensus
+  exposed-modules:
+    Data.SOP.Counting
+    Data.SOP.Functors
+    Data.SOP.Index
+    Data.SOP.InPairs
+    Data.SOP.Lenses
+    Data.SOP.Match
+    Data.SOP.NonEmpty
+    Data.SOP.OptNP
+    Data.SOP.Strict
+    Data.SOP.Tails
+    Data.SOP.Telescope
+    Ouroboros.Consensus.Block
+    Ouroboros.Consensus.Block.Abstract
+    Ouroboros.Consensus.Block.EBB
+    Ouroboros.Consensus.Block.Forging
+    Ouroboros.Consensus.Block.NestedContent
+    Ouroboros.Consensus.Block.RealPoint
+    Ouroboros.Consensus.Block.SupportsMetrics
+    Ouroboros.Consensus.Block.SupportsProtocol
+    Ouroboros.Consensus.BlockchainTime
+    Ouroboros.Consensus.BlockchainTime.API
+    Ouroboros.Consensus.BlockchainTime.WallClock.Default
+    Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+    Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+    Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Config
+    Ouroboros.Consensus.Config.SecurityParam
+    Ouroboros.Consensus.Config.SupportsNode
+    Ouroboros.Consensus.Forecast
+    Ouroboros.Consensus.Fragment.Diff
+    Ouroboros.Consensus.Fragment.InFuture
+    Ouroboros.Consensus.Fragment.Validated
+    Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.HardFork.Abstract
+    Ouroboros.Consensus.HardFork.Combinator
+    Ouroboros.Consensus.HardFork.Combinator.Abstract
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+    Ouroboros.Consensus.HardFork.Combinator.Basics
+    Ouroboros.Consensus.HardFork.Combinator.Block
+    Ouroboros.Consensus.HardFork.Combinator.Compat
+    Ouroboros.Consensus.HardFork.Combinator.Condense
+    Ouroboros.Consensus.HardFork.Combinator.Degenerate
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+    Ouroboros.Consensus.HardFork.Combinator.Forging
+    Ouroboros.Consensus.HardFork.Combinator.Info
+    Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+    Ouroboros.Consensus.HardFork.Combinator.Ledger
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    Ouroboros.Consensus.HardFork.Combinator.Lifting
+    Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.Node
+    Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+    Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+    Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+    Ouroboros.Consensus.HardFork.Combinator.Protocol
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+    Ouroboros.Consensus.HardFork.Combinator.State
+    Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    Ouroboros.Consensus.HardFork.Combinator.State.Instances
+    Ouroboros.Consensus.HardFork.Combinator.State.Lift
+    Ouroboros.Consensus.HardFork.Combinator.State.Types
+    Ouroboros.Consensus.HardFork.Combinator.Translation
+    Ouroboros.Consensus.HardFork.History
+    Ouroboros.Consensus.HardFork.History.Caching
+    Ouroboros.Consensus.HardFork.History.EpochInfo
+    Ouroboros.Consensus.HardFork.History.EraParams
+    Ouroboros.Consensus.HardFork.History.Qry
+    Ouroboros.Consensus.HardFork.History.Summary
+    Ouroboros.Consensus.HardFork.History.Util
+    Ouroboros.Consensus.HardFork.Simple
+    Ouroboros.Consensus.HeaderStateHistory
+    Ouroboros.Consensus.HeaderValidation
+    Ouroboros.Consensus.Ledger.Abstract
+    Ouroboros.Consensus.Ledger.Basics
+    Ouroboros.Consensus.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.Ledger.Dual
+    Ouroboros.Consensus.Ledger.Extended
+    Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Query
+    Ouroboros.Consensus.Ledger.Query.Version
+    Ouroboros.Consensus.Ledger.SupportsMempool
+    Ouroboros.Consensus.Ledger.SupportsPeerSelection
+    Ouroboros.Consensus.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Mempool
+    Ouroboros.Consensus.Mempool.API
+    Ouroboros.Consensus.Mempool.Capacity
+    Ouroboros.Consensus.Mempool.Impl.Common
+    Ouroboros.Consensus.Mempool.Init
+    Ouroboros.Consensus.Mempool.Query
+    Ouroboros.Consensus.Mempool.TxSeq
+    Ouroboros.Consensus.Mempool.Update
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+    Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.InitStorage
+    Ouroboros.Consensus.Node.NetworkProtocolVersion
+    Ouroboros.Consensus.Node.ProtocolInfo
+    Ouroboros.Consensus.Node.Run
+    Ouroboros.Consensus.Node.Serialisation
+    Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Protocol.Abstract
+    Ouroboros.Consensus.Protocol.BFT
+    Ouroboros.Consensus.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Protocol.MockChainSel
+    Ouroboros.Consensus.Protocol.ModChainSel
+    Ouroboros.Consensus.Protocol.PBFT
+    Ouroboros.Consensus.Protocol.PBFT.Crypto
+    Ouroboros.Consensus.Protocol.PBFT.State
+    Ouroboros.Consensus.Protocol.Signed
+    Ouroboros.Consensus.Storage.ChainDB
+    Ouroboros.Consensus.Storage.ChainDB.API
+    Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+    Ouroboros.Consensus.Storage.ChainDB.Impl
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+    Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
+    Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Query
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+    Ouroboros.Consensus.Storage.ChainDB.Init
+    Ouroboros.Consensus.Storage.Common
+    Ouroboros.Consensus.Storage.ImmutableDB
+    Ouroboros.Consensus.Storage.ImmutableDB.API
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
+    Ouroboros.Consensus.Storage.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+    Ouroboros.Consensus.Storage.LedgerDB.Init
+    Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.Query
+    Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+    Ouroboros.Consensus.Storage.LedgerDB.Stream
+    Ouroboros.Consensus.Storage.LedgerDB.Update
+    Ouroboros.Consensus.Storage.Serialisation
+    Ouroboros.Consensus.Storage.VolatileDB
+    Ouroboros.Consensus.Storage.VolatileDB.API
+    Ouroboros.Consensus.Storage.VolatileDB.Impl
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
+    Ouroboros.Consensus.Ticked
+    Ouroboros.Consensus.TypeFamilyWrappers
+    Ouroboros.Consensus.Util
+    Ouroboros.Consensus.Util.AnchoredFragment
+    Ouroboros.Consensus.Util.Args
+    Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.CallStack
+    Ouroboros.Consensus.Util.CBOR
+    Ouroboros.Consensus.Util.Condense
+    Ouroboros.Consensus.Util.DepPair
+    Ouroboros.Consensus.Util.EarlyExit
+    Ouroboros.Consensus.Util.Enclose
+    Ouroboros.Consensus.Util.FileLock
+    Ouroboros.Consensus.Util.HList
+    Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.MonadSTM.NormalForm
+    Ouroboros.Consensus.Util.MonadSTM.RAWLock
+    Ouroboros.Consensus.Util.MonadSTM.StrictSVar
+    Ouroboros.Consensus.Util.Orphans
+    Ouroboros.Consensus.Util.RedundantConstraints
+    Ouroboros.Consensus.Util.ResourceRegistry
+    Ouroboros.Consensus.Util.Singletons
+    Ouroboros.Consensus.Util.STM
+    Ouroboros.Consensus.Util.TentativeState
+    Ouroboros.Consensus.Util.Time
+    Ouroboros.Consensus.Util.TraceSize
+    Ouroboros.Consensus.Util.Versioned
+
+  other-extensions:
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DeriveAnyClass
+    DeriveFunctor
+    DeriveGeneric
+    EmptyDataDecls
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NamedFieldPuns
+    OverloadedStrings
+    PackageImports
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeInType
+    TypeOperators
+    UndecidableInstances
+    UndecidableSuperClasses
+    ViewPatterns
+
+  build-depends:
+    , base                         >=4.14     && <4.19
+    , base16-bytestring
+    , bimap                        >=0.4      && <0.6
+    , binary                       >=0.8      && <0.11
+    , bytestring                   >=0.10     && <0.12
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-prelude
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                        >=0.2.2    && <0.3
+    , containers                   >=0.5      && <0.7
+    , contra-tracer
+    , deepseq
+    , filelock
+    , fs-api                       ^>=0.1
+    , hashable
+    , io-classes                   ^>=1.1
+    , measures
+    , mtl
+    , nothunks                     >=0.1.2    && <0.2
+    , ouroboros-network-api        ^>=0.5
+    , ouroboros-network-mock       ^>=0.1.0.1
+    , ouroboros-network-protocols  ^>=0.5
+    , psqueues                     >=0.2.3    && <0.3
+    , quiet                        >=0.2      && <0.3
+    , semialign                    >=1.1
+    , serialise                    >=0.2      && <0.3
+    , si-timers                    ^>=1.1
+    , sop-core                     >=0.5      && <0.6
+    , streaming
+    , strict-stm                   ^>=1.1
+    , text                         ^>=2.0
+    , these                        ^>=1.2
+    , time
+    , transformers
+    , typed-protocols
+    , vector                       >=0.12     && <0.13
+
+library consensus-testlib
+  import:          common-lib
+  hs-source-dirs:  src/consensus-testlib
+  visibility:      public
+  exposed-modules:
+    Test.Util.BoolProps
+    Test.Util.ChainDB
+    Test.Util.ChainUpdates
+    Test.Util.ChunkInfo
+    Test.Util.Corruption
+    Test.Util.FileLock
+    Test.Util.HardFork.Future
+    Test.Util.HardFork.OracularClock
+    Test.Util.InvertedMap
+    Test.Util.LogicalClock
+    Test.Util.MockChain
+    Test.Util.Orphans.Arbitrary
+    Test.Util.Orphans.IOLike
+    Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.SignableRepresentation
+    Test.Util.Orphans.ToExpr
+    Test.Util.Paths
+    Test.Util.QSM
+    Test.Util.QuickCheck
+    Test.Util.Range
+    Test.Util.RefEnv
+    Test.Util.Schedule
+    Test.Util.Serialisation.Golden
+    Test.Util.Serialisation.Roundtrip
+    Test.Util.Shrink
+    Test.Util.Slots
+    Test.Util.SOP
+    Test.Util.Split
+    Test.Util.Stream
+    Test.Util.TestBlock
+    Test.Util.TestEnv
+    Test.Util.Time
+    Test.Util.Tracer
+    Test.Util.WithEq
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-prelude
+    , cardano-strict-containers
+    , cborg
+    , containers
+    , contra-tracer
+    , deepseq
+    , directory
+    , file-embed
+    , filepath
+    , fs-api                                                  ^>=0.1
+    , fs-sim                                                  ^>=0.2
+    , generics-sop
+    , io-sim
+    , mtl
+    , nothunks
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , QuickCheck
+    , quickcheck-state-machine
+    , quiet
+    , random
+    , serialise
+    , sop-core
+    , tasty
+    , tasty-golden
+    , tasty-quickcheck
+    , template-haskell
+    , time
+    , tree-diff
+    , utf8-string
+
+library mock-block
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/mock-block
+  exposed-modules:
+    Ouroboros.Consensus.Mock.Ledger
+    Ouroboros.Consensus.Mock.Ledger.Address
+    Ouroboros.Consensus.Mock.Ledger.Block
+    Ouroboros.Consensus.Mock.Ledger.Block.BFT
+    Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+    Ouroboros.Consensus.Mock.Ledger.Block.Praos
+    Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+    Ouroboros.Consensus.Mock.Ledger.Forge
+    Ouroboros.Consensus.Mock.Ledger.Stake
+    Ouroboros.Consensus.Mock.Ledger.State
+    Ouroboros.Consensus.Mock.Ledger.UTxO
+    Ouroboros.Consensus.Mock.Node
+    Ouroboros.Consensus.Mock.Node.Abstract
+    Ouroboros.Consensus.Mock.Node.BFT
+    Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Praos
+    Ouroboros.Consensus.Mock.Node.PraosRule
+    Ouroboros.Consensus.Mock.Node.Serialisation
+    Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Mock.Protocol.Praos
+
+  build-depends:
+    , base
+    , bimap
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , deepseq
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , serialise
+    , time
+
+library tutorials
+  import:         common-lib
+
+  if flag(expose-sublibs)
+    visibility: private
+
+  else
+    visibility: public
+
+  hs-source-dirs: src/tutorials
+  other-modules:
+    Ouroboros.Consensus.Tutorial.Simple
+    Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:
+    , base
+    , containers
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , serialise
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.HardFork.Forecast
+    Test.Consensus.HardFork.History
+    Test.Consensus.HardFork.Infra
+    Test.Consensus.HardFork.Summary
+    Test.Consensus.Mempool
+    Test.Consensus.Mempool.Fairness
+    Test.Consensus.Mempool.Fairness.TestBlock
+    Test.Consensus.MiniProtocol.BlockFetch.Client
+    Test.Consensus.MiniProtocol.ChainSync.Client
+    Test.Consensus.MiniProtocol.LocalStateQuery.Server
+    Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.NormalForm
+    Test.Consensus.Util.MonadSTM.RAWLock
+    Test.Consensus.Util.Versioned
+
+  build-depends:
+    , async
+    , base
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , fs-api                                                              ^>=0.1
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mock-block
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , QuickCheck
+    , quickcheck-state-machine
+    , random
+    , serialise
+    , si-timers
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , time
+    , tree-diff
+    , typed-protocols
+    , typed-protocols-examples
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:
+    Ouroboros.Consensus.Util.Tests
+    Test.Util.ChainUpdates.Tests
+    Test.Util.Schedule.Tests
+    Test.Util.Split.Tests
+
+  build-depends:
+    , base
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , tasty
+    , tasty-quickcheck
+
+test-suite storage-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/storage-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Ouroboros.Storage
+    Test.Ouroboros.Storage.ChainDB
+    Test.Ouroboros.Storage.ChainDB.FollowerPromptness
+    Test.Ouroboros.Storage.ChainDB.GcSchedule
+    Test.Ouroboros.Storage.ChainDB.Iterator
+    Test.Ouroboros.Storage.ChainDB.Model
+    Test.Ouroboros.Storage.ChainDB.Model.Test
+    Test.Ouroboros.Storage.ChainDB.Paths
+    Test.Ouroboros.Storage.ChainDB.StateMachine
+    Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl
+    Test.Ouroboros.Storage.ChainDB.Unit
+    Test.Ouroboros.Storage.ImmutableDB
+    Test.Ouroboros.Storage.ImmutableDB.Mock
+    Test.Ouroboros.Storage.ImmutableDB.Model
+    Test.Ouroboros.Storage.ImmutableDB.Primary
+    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    Test.Ouroboros.Storage.LedgerDB
+    Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+    Test.Ouroboros.Storage.LedgerDB.InMemory
+    Test.Ouroboros.Storage.LedgerDB.OnDisk
+    Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
+    Test.Ouroboros.Storage.Orphans
+    Test.Ouroboros.Storage.TestBlock
+    Test.Ouroboros.Storage.VolatileDB
+    Test.Ouroboros.Storage.VolatileDB.Mock
+    Test.Ouroboros.Storage.VolatileDB.Model
+    Test.Ouroboros.Storage.VolatileDB.StateMachine
+
+  build-depends:
+    , base
+    , bifunctors
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , fs-api                    ^>=0.1
+    , fs-sim                    >=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  ^>=0.7
+    , random
+    , serialise
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , time
+    , transformers
+    , tree-diff
+    , vector
+
+benchmark mempool-bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench/mempool-bench
+  main-is:          Main.hs
+  other-modules:
+    Bench.Consensus.Mempool
+    Bench.Consensus.Mempool.TestBlock
+    Bench.Consensus.MempoolWithMockedLedgerItf
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-slotting
+    , cassava
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , nothunks
+    , ouroboros-consensus
+    , serialise
+    , strict-stm
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , text
+    , transformers
+    , tree-diff
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64


### PR DESCRIPTION
New versions of `fs-api` and `fs-sim` require revisions to old `ouroboros-consensus` versions, since they don't have upper bounds on `fs-api` and `fs-sim`, which breaks their builds and makes the smoke tests fail.