### PR TITLE
Ledger ghc 9.6 compat packages

### DIFF
--- a/_sources/cardano-ledger-shelley-test/1.2.0.2/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.2.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-01T11:25:26Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "ecdb9c76a3252e1e6fbb8ed743796bf44cc83dbc" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/small-steps-test/1.0.0.1/meta.toml
+++ b/_sources/small-steps-test/1.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-01T11:25:26Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "ecdb9c76a3252e1e6fbb8ed743796bf44cc83dbc" }
+subdir = 'libs/small-steps-test'


### PR DESCRIPTION
Couple of the test packages didn't get released when ghc-9.6. compatibility was being implemented. This is the release of those packages