### PR TITLE
Added revisioned ledger packages for GHC9.6

### DIFF
--- a/_sources/cardano-crypto-test/1.5.0.0/meta.toml
+++ b/_sources/cardano-crypto-test/1.5.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'eras/byron/crypto/test'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/cardano-crypto-test/1.5.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-test/1.5.0.0/revisions/1.cabal
@@ -1,0 +1,63 @@
+cabal-version: 3.0
+name:          cardano-crypto-test
+version:       1.5.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+synopsis:      Test helpers from cardano-crypto exposed to other packages
+description:   Test helpers from cardano-crypto exposed to other packages
+category:      Currency
+build-type:    Simple
+data-files:
+    golden/AbstractHash
+    golden/DecShare
+    golden/EncShare
+    golden/PassPhrase
+    golden/RedeemSignature
+    golden/RedeemSigningKey
+    golden/RedeemVerificationKey
+    golden/Secret
+    golden/SecretProof
+    golden/Signature
+    golden/SigningKey
+    golden/VerificationKey
+    golden/VssPublicKey
+    golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+library
+    exposed-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Orphans
+
+    cpp-options:        -DCARDANO_CRYPTO_TEST
+    other-modules:
+        Paths_cardano_crypto_test
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Weverything -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
+        cardano-crypto,
+        cardano-crypto-wrapper ^>=1.5,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.5.1.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-05T21:25:44Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f10f06f6ab96b5ee52a28ccc45b41a592efde4b7" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/1.cabal
@@ -1,0 +1,138 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary >=1.0,
+        cardano-crypto,
+        cardano-prelude >=0.1.0.1,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-data/1.1.0.0/meta.toml
+++ b/_sources/cardano-data/1.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-11T21:41:19Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
 subdir = 'libs/cardano-data'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/cardano-data/1.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-data/1.1.0.0/revisions/1.cabal
@@ -1,0 +1,74 @@
+cabal-version:      3.0
+name:               cardano-data
+version:            1.1.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:           Specialized data for Cardano project
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-data
+
+library
+    exposed-modules:
+        Data.CanonicalMaps
+        Data.Pulse
+        Data.MapExtras
+        Data.ListMap
+        Data.Universe
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        cardano-ledger-binary >=1.0,
+        containers,
+        deepseq,
+        mtl,
+        nothunks,
+        vector
+
+library testlib
+    exposed-modules:  Test.Cardano.Data
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        containers,
+        hspec,
+        QuickCheck
+
+test-suite cardano-data-tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:    Test.Cardano.Data.MapExtrasSpec
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        hspec,
+        cardano-data,
+        testlib,
+        QuickCheck

--- a/_sources/non-integral/1.0.0.0/meta.toml
+++ b/_sources/non-integral/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'libs/non-integral'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/non-integral/1.0.0.0/revisions/1.cabal
+++ b/_sources/non-integral/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,42 @@
+cabal-version:      3.0
+name:               non-integral
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+description:        Implementation decision for non-integer calculations
+build-type:         Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger.git
+    subdir:   libs/non-integral
+
+library
+    exposed-modules:  Cardano.Ledger.NonIntegral
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:    base >=4.14 && <4.19
+
+test-suite non-integral-test
+    type:             exitcode-stdio-1.0
+    main-is:          Tests.hs
+    hs-source-dirs:   test
+    other-modules:    Tests.Cardano.Ledger.NonIntegral
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -O2 -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        non-integral,
+        QuickCheck

--- a/_sources/set-algebra/1.1.0.1/meta.toml
+++ b/_sources/set-algebra/1.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-06-08T18:20:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "eae43793dc80533fe7f3fc02b76303e7df7d001f" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/set-algebra/1.1.0.1/revisions/1.cabal
+++ b/_sources/set-algebra/1.1.0.1/revisions/1.cabal
@@ -1,0 +1,59 @@
+cabal-version:      3.0
+name:               set-algebra
+version:            1.1.0.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:           Set Algebra
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/set-algebra
+
+library
+    exposed-modules:
+        Control.Iterate.BaseTypes
+        Control.Iterate.Collect
+        Control.Iterate.Exp
+        Control.Iterate.SetAlgebra
+        Control.SetAlgebra
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        ansi-wl-pprint <1.0,
+        cardano-data >=1.1,
+        containers
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Control.Iterate.SetAlgebra
+        Test.Control.Iterate.RelationReference
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        set-algebra,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        cardano-data

--- a/_sources/small-steps/1.0.0.0/meta.toml
+++ b/_sources/small-steps/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'libs/small-steps'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/small-steps/1.0.0.0/revisions/1.cabal
+++ b/_sources/small-steps/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,50 @@
+cabal-version:      3.0
+name:               small-steps
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:           Small step semantics
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/small-steps
+
+flag sts_assert
+    description: Enable STS assertions by default
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Control.State.Transition
+        Control.State.Transition.Extended
+        Control.State.Transition.Simple
+        Control.Provenance
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        aeson,
+        base >=4.14 && <4.19,
+        containers,
+        data-default-class,
+        free,
+        mtl,
+        nothunks,
+        cardano-strict-containers,
+        text,
+        transformers >=0.5,
+        validation-selective
+
+    if flag(sts_assert)
+        cpp-options: -DSTS_ASSERT

--- a/_sources/vector-map/1.0.1.0/meta.toml
+++ b/_sources/vector-map/1.0.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-05T21:13:03Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f10f06f6ab96b5ee52a28ccc45b41a592efde4b7" }
 subdir = 'libs/vector-map'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-02T11:20:00Z

--- a/_sources/vector-map/1.0.1.0/revisions/1.cabal
+++ b/_sources/vector-map/1.0.1.0/revisions/1.cabal
@@ -1,0 +1,74 @@
+cabal-version:      3.0
+name:               vector-map
+version:            1.0.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/input-output-hk/cardano-ledger
+synopsis:
+    An efficient VMap that is backed by two vectors: one for keys and another for values.
+
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/vector-map
+
+library
+    exposed-modules:  Data.VMap
+    hs-source-dirs:   src
+    other-modules:    Data.VMap.KVVector
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        containers,
+        deepseq,
+        nothunks,
+        primitive,
+        tree-diff,
+        vector,
+        vector-algorithms
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Common
+        Test.VMap
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        tasty,
+        tasty-quickcheck,
+        vector-map,
+        QuickCheck,
+        quickcheck-classes-base
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:      -Wall -threaded -O2 -rtsopts
+    build-depends:
+        base,
+        criterion,
+        vector-map,
+        containers,
+        random


### PR DESCRIPTION
These cabal files are taken from `cardano-ledger@master`. They were already updated, but they had not been published yet.

Diff:

```diff
diff --git a/cardano-crypto-test.cabal b/_sources/cardano-crypto-test/1.5.0.0/revisions/1.cabal
index 6914047d..6eebb78c 100644
--- a/cardano-crypto-test.cabal
+++ b/_sources/cardano-crypto-test/1.5.0.0/revisions/1.cabal
@@ -51,10 +51,9 @@ library
         -Wno-safe -Wno-unsafe -Wunused-packages
 
     build-depends:
-        base >=4.12 && <4.17,
+        base >=4.14 && <4.19,
         bytestring,
-        cardano-ledger-binary,
-        cardano-ledger-binary:testlib,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-crypto,
         cardano-crypto-wrapper ^>=1.5,
         cardano-prelude,
diff --git a/cardano-crypto-wrapper.cabal b/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/1.cabal
index 0a90d9fa..e5bff17a 100644
--- a/cardano-crypto-wrapper.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/1.cabal
@@ -73,7 +73,7 @@ library
         -Wno-safe -Wno-unsafe -Wunused-packages
 
     build-depends:
-        base >=4.14 && <4.17,
+        base >=4.14 && <4.19,
         aeson,
         base16-bytestring >=1,
         base64-bytestring,
diff --git a/cardano-data.cabal b/_sources/cardano-data/1.1.0.0/revisions/1.cabal
index d681e7af..3907e24a 100644
--- a/cardano-data.cabal
+++ b/_sources/cardano-data/1.1.0.0/revisions/1.cabal
@@ -30,7 +30,7 @@ library
         -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
 
     build-depends:
-        base >=4.14 && <4.17,
+        base >=4.14 && <4.19,
         aeson,
         cardano-ledger-binary >=1.0,
         containers,
diff --git a/non-integral.cabal b/_sources/non-integral/1.0.0.0/revisions/1.cabal
index f824d787..54771f71 100644
--- a/non-integral.cabal
+++ b/_sources/non-integral/1.0.0.0/revisions/1.cabal
@@ -23,7 +23,7 @@ library
         -Wall -Wcompat -Wincomplete-record-updates
         -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
 
-    build-depends:    base >=4.12 && <4.17
+    build-depends:    base >=4.14 && <4.19
 
 test-suite non-integral-test
     type:             exitcode-stdio-1.0
@@ -37,6 +37,6 @@ test-suite non-integral-test
         -O2 -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.12 && <4.17,
+        base,
         non-integral,
         QuickCheck
diff --git a/small-steps.cabal b/_sources/small-steps/1.0.0.0/revisions/1.cabal
index 1ec5d42d..bdc04a82 100644
--- a/small-steps.cabal
+++ b/_sources/small-steps/1.0.0.0/revisions/1.cabal
@@ -34,8 +34,8 @@ library
         -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
 
     build-depends:
-        base >=4.12 && <4.17,
         aeson,
+        base >=4.14 && <4.19,
         containers,
         data-default-class,
         free,
diff --git a/vector-map.cabal b/_sources/vector-map/1.0.1.0/revisions/1.cabal
index b1cd3b44..a79627cc 100644
--- a/vector-map.cabal
+++ b/_sources/vector-map/1.0.1.0/revisions/1.cabal
@@ -27,7 +27,7 @@ library
         -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
 
     build-depends:
-        base >=4.14 && <4.17,
+        base >=4.14 && <4.19,
         aeson,
         containers,
         deepseq,
```