### PR TITLE
Added int-cast-0.2.0.0.0.0.0.0.2

### DIFF
--- a/_sources/int-cast/0.2.0.0.0.0.0.0.2/meta.toml
+++ b/_sources/int-cast/0.2.0.0.0.0.0.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-02T12:17:24Z
+github = { repo = "input-output-hk/int-cast", rev = "a95a5eb8d3a4633a2230dd058b38b7ae82dd19a2" }
+force-version = true


### PR DESCRIPTION
From https://github.com/input-output-hk/int-cast at a95a5eb8d3a4633a2230dd058b38b7ae82dd19a2

Compatible with GHC 9.6
