### PR TITLE
Release Consensus packages enabling the 8.3 node pre-release

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.8.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.8.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-21T16:55:07Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "42dbbf4b5daed4c6d3cc047690535c5bdcf6ff81" }
+subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-diffusion/0.7.1.1/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.7.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-21T16:55:07Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "42dbbf4b5daed4c6d3cc047690535c5bdcf6ff81" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-protocol/0.5.0.6/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.5.0.6/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-21T16:55:07Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "42dbbf4b5daed4c6d3cc047690535c5bdcf6ff81" }
+subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus/0.10.0.1/meta.toml
+++ b/_sources/ouroboros-consensus/0.10.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-08-21T16:55:07Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "42dbbf4b5daed4c6d3cc047690535c5bdcf6ff81" }
+subdir = 'ouroboros-consensus'


### PR DESCRIPTION
The follow-up to https://github.com/input-output-hk/ouroboros-consensus/pull/301 and https://github.com/input-output-hk/ouroboros-consensus/pull/308

Notably: integrates the release of `cardano-ledger-conway-1.7.0.0`.

Closes https://github.com/input-output-hk/ouroboros-consensus/issues/303.