### PR TITLE
Consensus: expose private sublibraries

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -47,6 +47,20 @@ let
         '';
       });
 
+      tweak =
+        if lib.hasPrefix "ouroboros-consensus" package-name
+        # otherwise, certain sublibraries (used for test suites) are marked as
+        # hidden and cause build failures (as they depend on each other)
+        then a: a.passthru.addCabalProject ''
+          package ouroboros-consensus
+            flags: +expose-sublibs
+          package ouroboros-consensus-protocol
+            flags: +expose-sublibs
+          package ouroboros-consensus-diffusion
+            flags: +expose-sublibs
+        ''
+        else a: a;
+
       # Wrapper around all package components
       #
       # The wrapper also provides shortcuts to quickly manipulate the cabal project.
@@ -85,6 +99,6 @@ let
           };
         };
     in
-    aggregate project;
+    tweak (aggregate project);
 in
 build-chap-package


### PR DESCRIPTION
CHaP CI builds *all* components of a given project, but eg ouroboros-consensus-cardano has private-by-default sublibraries (used for tests), which themselves depend on other private-by-default sublibraries in eg ouroboros-consensus-diffusion, which causes failures at build time.

In this commit, we make the sublibraries public by enabling the respective flags.

Alternatives include:

 - Patch Consensus to always make the sublibraries public.

 - Don't build all (in particular private) sublibraries in CHaP CI (not sure if that is easily possible to do automatically).

