### PR TITLE
Consensus: mark private sublibs as unbuildable

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.8.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.8.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-19T21:30:30Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "2097e06a2ede5ba49ec54fed76763af18bc7fccf" }
 subdir = 'ouroboros-consensus-cardano'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-21T08:45:47Z

--- a/_sources/ouroboros-consensus-cardano/0.8.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.8.0.0/revisions/1.cabal
@@ -1,0 +1,614 @@
+cabal-version:   3.0
+name:            ouroboros-consensus-cardano
+version:         0.8.0.0
+synopsis:
+  The instantation of the Ouroboros consensus layer used by Cardano
+
+description:
+  The instantation of the Ouroboros consensus layer used by Cardano.
+
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+common common-exe
+  import:      common-lib
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-N -I0 -A16m"
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus-cardano src/byron src/shelley
+  exposed-modules:
+    Ouroboros.Consensus.Byron.Crypto.DSIGN
+    Ouroboros.Consensus.Byron.EBBs
+    Ouroboros.Consensus.Byron.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Block
+    Ouroboros.Consensus.Byron.Ledger.Config
+    Ouroboros.Consensus.Byron.Ledger.Conversions
+    Ouroboros.Consensus.Byron.Ledger.Forge
+    Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+    Ouroboros.Consensus.Byron.Ledger.Inspect
+    Ouroboros.Consensus.Byron.Ledger.Integrity
+    Ouroboros.Consensus.Byron.Ledger.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Mempool
+    Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Byron.Ledger.Orphans
+    Ouroboros.Consensus.Byron.Ledger.PBFT
+    Ouroboros.Consensus.Byron.Ledger.Serialisation
+    Ouroboros.Consensus.Byron.Node
+    Ouroboros.Consensus.Byron.Node.Serialisation
+    Ouroboros.Consensus.Byron.Protocol
+    Ouroboros.Consensus.Cardano
+    Ouroboros.Consensus.Cardano.Block
+    Ouroboros.Consensus.Cardano.ByronHFC
+    Ouroboros.Consensus.Cardano.CanHardFork
+    Ouroboros.Consensus.Cardano.Condense
+    Ouroboros.Consensus.Cardano.Node
+    Ouroboros.Consensus.Cardano.ShelleyBased
+    Ouroboros.Consensus.Shelley.Crypto
+    Ouroboros.Consensus.Shelley.Eras
+    Ouroboros.Consensus.Shelley.HFEras
+    Ouroboros.Consensus.Shelley.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Block
+    Ouroboros.Consensus.Shelley.Ledger.Config
+    Ouroboros.Consensus.Shelley.Ledger.Forge
+    Ouroboros.Consensus.Shelley.Ledger.Inspect
+    Ouroboros.Consensus.Shelley.Ledger.Integrity
+    Ouroboros.Consensus.Shelley.Ledger.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Mempool
+    Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+    Ouroboros.Consensus.Shelley.Ledger.Protocol
+    Ouroboros.Consensus.Shelley.Ledger.Query
+    Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Shelley.Node
+    Ouroboros.Consensus.Shelley.Node.Common
+    Ouroboros.Consensus.Shelley.Node.Praos
+    Ouroboros.Consensus.Shelley.Node.Serialisation
+    Ouroboros.Consensus.Shelley.Node.TPraos
+    Ouroboros.Consensus.Shelley.Protocol.Abstract
+    Ouroboros.Consensus.Shelley.Protocol.Praos
+    Ouroboros.Consensus.Shelley.Protocol.TPraos
+    Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  other-modules:
+    Ouroboros.Consensus.Shelley.Ledger.Query.PParamsLegacyEncoder
+
+  build-depends:
+    , base                          >=4.14     && <4.19
+    , base-deriving-via
+    , bytestring                    >=0.10     && <0.12
+    , cardano-binary
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo         ^>=1.4
+    , cardano-ledger-api            ^>=1.4
+    , cardano-ledger-babbage        ^>=1.4
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway         ^>=1.7
+    , cardano-ledger-core           ^>=1.5
+    , cardano-ledger-mary
+    , cardano-ledger-shelley        ^>=1.5
+    , cardano-prelude
+    , cardano-protocol-tpraos       >=1.0.1    && <1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                         >=0.2.2    && <0.3
+    , containers                    >=0.5      && <0.7
+    , cryptonite                    >=0.25     && <0.31
+    , deepseq
+    , formatting                    >=6.3      && <7.2
+    , measures
+    , microlens
+    , mtl
+    , nothunks
+    , ouroboros-consensus           ^>=0.10
+    , ouroboros-consensus-protocol  ^>=0.5.0.1
+    , ouroboros-network-api         ^>=0.5
+    , serialise                     >=0.2      && <0.3
+    , small-steps
+    , text                          ^>=2.0
+    , these                         ^>=1.2
+    , vector-map
+
+library byronspec
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/byronspec
+  exposed-modules:
+    Ouroboros.Consensus.ByronSpec.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Accessors
+    Ouroboros.Consensus.ByronSpec.Ledger.Block
+    Ouroboros.Consensus.ByronSpec.Ledger.Conversions
+    Ouroboros.Consensus.ByronSpec.Ledger.Forge
+    Ouroboros.Consensus.ByronSpec.Ledger.Genesis
+    Ouroboros.Consensus.ByronSpec.Ledger.GenTx
+    Ouroboros.Consensus.ByronSpec.Ledger.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Mempool
+    Ouroboros.Consensus.ByronSpec.Ledger.Orphans
+    Ouroboros.Consensus.ByronSpec.Ledger.Rules
+
+  build-depends:
+    , base                       >=4.14  && <4.19
+    , bimap                      >=0.4   && <0.6
+    , byron-spec-chain
+    , byron-spec-ledger
+    , cardano-ledger-binary
+    , cardano-ledger-byron-test
+    , cborg                      >=0.2.2 && <0.3
+    , containers                 >=0.5   && <0.7
+    , mtl
+    , nothunks
+    , ouroboros-consensus        ^>=0.10
+    , serialise                  >=0.2   && <0.3
+    , small-steps
+    , transformers
+
+library byron-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/byron-testlib
+  exposed-modules:
+    Ouroboros.Consensus.ByronDual.Ledger
+    Ouroboros.Consensus.ByronDual.Node
+    Ouroboros.Consensus.ByronDual.Node.Serialisation
+    Test.Consensus.Byron.Examples
+    Test.Consensus.Byron.Generators
+    Test.ThreadNet.Infra.Byron
+    Test.ThreadNet.Infra.Byron.Genesis
+    Test.ThreadNet.Infra.Byron.ProtocolInfo
+    Test.ThreadNet.Infra.Byron.TrackUpdates
+    Test.ThreadNet.TxGen.Byron
+
+  build-depends:
+    , base
+    , byron-spec-ledger
+    , byronspec
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-test
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , containers
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , serialise
+
+test-suite byron-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/byron-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Byron.Golden
+    Test.Consensus.Byron.Serialisation
+    Test.ThreadNet.Byron
+    Test.ThreadNet.DualByron
+
+  build-depends:
+    , base
+    , binary-search
+    , byron-spec-chain
+    , byron-spec-ledger
+    , byron-testlib
+    , byronspec
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , cborg
+    , containers
+    , filepath
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-mock
+    , QuickCheck
+    , small-steps
+    , small-steps-test
+    , tasty
+    , tasty-quickcheck
+
+library shelley-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/shelley-testlib
+  exposed-modules:
+    Test.Consensus.Shelley.Examples
+    Test.Consensus.Shelley.Generators
+    Test.Consensus.Shelley.MockCrypto
+    Test.ThreadNet.Infra.Shelley
+    Test.ThreadNet.TxGen.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-babbage
+    , cardano-ledger-babbage-test
+    , cardano-ledger-conway-test                                                     >=1.2.0.1
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-mary
+    , cardano-ledger-shelley-ma-test
+    , cardano-ledger-shelley-test
+    , cardano-ledger-shelley:{cardano-ledger-shelley, testlib}
+    , cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib}
+    , cardano-strict-containers
+    , containers
+    , generic-random
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , quiet                                                                          >=0.2     && <0.3
+    , small-steps
+
+test-suite shelley-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/shelley-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Shelley.Coherence
+    Test.Consensus.Shelley.Golden
+    Test.Consensus.Shelley.Serialisation
+    Test.ThreadNet.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cborg
+    , containers
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , shelley-testlib
+    , tasty
+    , tasty-quickcheck
+
+library cardano-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/cardano-testlib
+  exposed-modules:
+    Test.Consensus.Cardano.Examples
+    Test.Consensus.Cardano.Generators
+    Test.Consensus.Cardano.MockCrypto
+    Test.Consensus.Cardano.ProtocolInfo
+    Test.ThreadNet.Infra.ShelleyBasedHardFork
+    Test.ThreadNet.Infra.TwoEras
+    Test.ThreadNet.TxGen.Allegra
+    Test.ThreadNet.TxGen.Alonzo
+    Test.ThreadNet.TxGen.Babbage
+    Test.ThreadNet.TxGen.Cardano
+    Test.ThreadNet.TxGen.Mary
+
+  build-depends:
+    , base
+    , byron-testlib
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-byron
+    , cardano-ledger-conway-test                                                        ^>=1.2.0.1
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-shelley                                                            ^>=1.5
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cardano-strict-containers
+    , containers
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:{ouroboros-consensus-diffusion, diffusion-testlib}
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , shelley-testlib
+
+test-suite cardano-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/cardano-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Cardano.ByronCompatibility
+    Test.Consensus.Cardano.Golden
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
+    Test.Consensus.Cardano.Serialisation
+    Test.ThreadNet.AllegraMary
+    Test.ThreadNet.Cardano
+    Test.ThreadNet.MaryAlonzo
+    Test.ThreadNet.ShelleyAllegra
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , byron-testlib
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cardano-testlib
+    , cborg
+    , containers
+    , contra-tracer
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-testlib}
+    , ouroboros-consensus-diffusion:diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib, mempool-test-utils}
+    , ouroboros-network-api
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , pretty-simple
+    , QuickCheck
+    , shelley-testlib
+    , sop-core
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , typed-protocols
+
+library cardano-tools
+  import:          common-lib
+  hs-source-dirs:  src/tools
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  exposed-modules:
+    Cardano.Api.Any
+    Cardano.Api.Protocol.Types
+    Cardano.Node.Protocol
+    Cardano.Node.Protocol.Types
+    Cardano.Node.Types
+    Cardano.Tools.DBAnalyser.Analysis
+    Cardano.Tools.DBAnalyser.Block.Byron
+    Cardano.Tools.DBAnalyser.Block.Cardano
+    Cardano.Tools.DBAnalyser.Block.Shelley
+    Cardano.Tools.DBAnalyser.HasAnalysis
+    Cardano.Tools.DBAnalyser.Run
+    Cardano.Tools.DBAnalyser.Types
+    Cardano.Tools.DBSynthesizer.Forging
+    Cardano.Tools.DBSynthesizer.Orphans
+    Cardano.Tools.DBSynthesizer.Run
+    Cardano.Tools.DBSynthesizer.Types
+    Cardano.Tools.DBTruncater.Run
+    Cardano.Tools.DBTruncater.Types
+    Cardano.Tools.ImmDBServer.Diffusion
+    Cardano.Tools.ImmDBServer.MiniProtocols
+
+  other-modules:
+    Cardano.Api.Key
+    Cardano.Api.KeysByron
+    Cardano.Api.KeysPraos
+    Cardano.Api.KeysShelley
+    Cardano.Api.OperationalCertificate
+    Cardano.Api.SerialiseTextEnvelope
+    Cardano.Api.SerialiseUsing
+    Cardano.Node.Protocol.Alonzo
+    Cardano.Node.Protocol.Byron
+    Cardano.Node.Protocol.Cardano
+    Cardano.Node.Protocol.Conway
+    Cardano.Node.Protocol.Shelley
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
+
+  build-depends:
+    , aeson
+    , base                           >=4.14  && <4.19
+    , base16-bytestring              >=1.0
+    , bytestring                     >=0.10  && <0.12
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-prelude
+    , cardano-protocol-tpraos        >=1.0.1 && <1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                          >=0.2.2 && <0.3
+    , containers                     >=0.5   && <0.7
+    , contra-tracer
+    , directory
+    , filepath
+    , fs-api                         ^>=0.2
+    , microlens
+    , mtl
+    , network
+    , nothunks
+    , ouroboros-consensus            ^>=0.10
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion  ^>=0.7
+    , ouroboros-consensus-protocol   ^>=0.5
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-protocols
+    , serialise                      >=0.2   && <0.3
+    , text
+    , text-builder
+    , transformers
+    , transformers-except
+
+executable db-analyser
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-analyser.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-tools}
+
+  other-modules:  DBAnalyser.Parsers
+
+executable db-synthesizer
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-synthesizer.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-tools
+    , optparse-applicative
+    , ouroboros-consensus
+
+  other-modules:  DBSynthesizer.Parsers
+
+executable db-truncater
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-truncater.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, cardano-tools}
+
+  other-modules:
+    DBAnalyser.Parsers
+    DBTruncater.Parsers
+
+executable immdb-server
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        immdb-server.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , network
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:cardano-tools
+
+test-suite tools-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/tools-test
+  main-is:        Main.hs
+  build-depends:
+    , base
+    , cardano-tools
+    , ouroboros-consensus:consensus-testlib
+    , tasty
+    , tasty-hunit

--- a/_sources/ouroboros-consensus-diffusion/0.7.1.0/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.7.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-19T21:30:30Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "2097e06a2ede5ba49ec54fed76763af18bc7fccf" }
 subdir = 'ouroboros-consensus-diffusion'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-21T08:45:20Z

--- a/_sources/ouroboros-consensus-diffusion/0.7.1.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-diffusion/0.7.1.0/revisions/1.cabal
@@ -1,0 +1,249 @@
+cabal-version:   3.0
+name:            ouroboros-consensus-diffusion
+version:         0.7.1.0
+synopsis:        Integration for the Ouroboros Network layer
+description:
+  Top level integration for consensus & network layers of the Ouroboros blockchain protocol.
+
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2022-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:             common-lib
+  hs-source-dirs:     src/ouroboros-consensus-diffusion
+  exposed-modules:
+    Ouroboros.Consensus.Network.NodeToClient
+    Ouroboros.Consensus.Network.NodeToNode
+    Ouroboros.Consensus.Node
+    Ouroboros.Consensus.Node.DbLock
+    Ouroboros.Consensus.Node.DbMarker
+    Ouroboros.Consensus.Node.ErrorPolicy
+    Ouroboros.Consensus.Node.Exit
+    Ouroboros.Consensus.Node.ExitPolicy
+    Ouroboros.Consensus.Node.Recovery
+    Ouroboros.Consensus.Node.RethrowPolicy
+    Ouroboros.Consensus.Node.Tracers
+    Ouroboros.Consensus.NodeKernel
+
+  reexported-modules:
+    Ouroboros.Consensus.Block
+    , Ouroboros.Consensus.Node.Run
+    , Ouroboros.Consensus.Node.NetworkProtocolVersion
+
+  build-depends:
+    , base                         >=4.14   && <4.19
+    , bytestring                   >=0.10   && <0.12
+    , cborg                        ^>=0.2.2
+    , containers                   >=0.5    && <0.7
+    , contra-tracer
+    , deepseq
+    , filepath
+    , fs-api                       ^>=0.2
+    , hashable
+    , io-classes                   ^>=1.1
+    , mtl
+    , ouroboros-consensus          ^>=0.10
+    , ouroboros-network            >=0.7    && <0.8  || ^>=0.8
+    , ouroboros-network-api        ^>=0.5
+    , ouroboros-network-framework  ^>=0.7
+    , ouroboros-network-protocols  ^>=0.5
+    , random
+    , serialise                    ^>=0.2
+    , si-timers                    ^>=1.1
+    , text                         ^>=2.0
+    , time
+    , transformers
+    , typed-protocols
+
+library diffusion-testlib
+  import:          common-lib
+  hs-source-dirs:  src/diffusion-testlib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  exposed-modules:
+    Test.ThreadNet.General
+    Test.ThreadNet.Network
+    Test.ThreadNet.Ref.PBFT
+    Test.ThreadNet.Rekeying
+    Test.ThreadNet.TxGen
+    Test.ThreadNet.Util
+    Test.ThreadNet.Util.Expectations
+    Test.ThreadNet.Util.HasCreator
+    Test.ThreadNet.Util.NodeJoinPlan
+    Test.ThreadNet.Util.NodeRestarts
+    Test.ThreadNet.Util.NodeToNodeVersion
+    Test.ThreadNet.Util.NodeTopology
+    Test.ThreadNet.Util.Seed
+
+  build-depends:
+    , base
+    , bytestring
+    , cborg
+    , containers
+    , contra-tracer
+    , fgl
+    , fs-sim                                                        ^>=0.2
+    , graphviz                                                      >=2999.20.1.0
+    , io-classes
+    , io-sim
+    , mtl
+    , ouroboros-consensus-diffusion
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-mock
+    , ouroboros-network-protocols
+    , QuickCheck
+    , quiet                                                         >=0.2         && <0.3
+    , random
+    , si-timers
+    , text
+    , typed-protocols
+
+library mock-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/mock-testlib
+  exposed-modules:
+    Test.Consensus.Ledger.Mock.Generators
+    Test.ThreadNet.TxGen.Mock
+    Test.ThreadNet.Util.HasCreator.Mock
+    Test.ThreadNet.Util.SimpleBlock
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , containers
+    , diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib, mock-block}
+    , QuickCheck
+    , serialise
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:  Test.ThreadNet.Util.Tests
+  build-depends:
+    , base
+    , diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , tasty
+    , tasty-quickcheck
+
+test-suite mock-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/mock-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Ledger.Mock
+    Test.ThreadNet.BFT
+    Test.ThreadNet.LeaderSchedule
+    Test.ThreadNet.PBFT
+    Test.ThreadNet.Praos
+
+  build-depends:
+    , base
+    , bytestring
+    , cborg
+    , containers
+    , diffusion-testlib
+    , mock-testlib
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib, mock-block}
+    , ouroboros-network-mock
+    , QuickCheck
+    , serialise
+    , tasty
+    , tasty-quickcheck
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.HardFork.Combinator
+    Test.Consensus.HardFork.Combinator.A
+    Test.Consensus.HardFork.Combinator.B
+    Test.Consensus.Node
+
+  build-depends:
+    , base
+    , binary
+    , bytestring
+    , cardano-slotting
+    , containers
+    , diffusion-testlib
+    , directory
+    , fs-api                                                        ^>=0.2
+    , fs-sim                                                        ^>=0.2
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus-diffusion
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , QuickCheck
+    , quiet
+    , serialise
+    , si-timers
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , temporary
+    , time

--- a/_sources/ouroboros-consensus-protocol/0.5.0.5/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.5.0.5/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-19T21:30:30Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "2097e06a2ede5ba49ec54fed76763af18bc7fccf" }
 subdir = 'ouroboros-consensus-protocol'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-21T08:45:32Z

--- a/_sources/ouroboros-consensus-protocol/0.5.0.5/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-protocol/0.5.0.5/revisions/1.cabal
@@ -1,0 +1,95 @@
+cabal-version:   3.0
+name:            ouroboros-consensus-protocol
+version:         0.5.0.5
+synopsis:        Cardano consensus protocols
+description:     Cardano consensus protocols.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2021-2023 Input Output Global Inc (IOG)
+author:          IOHK Formal methods team
+maintainer:      operations@iohk.io
+category:        Network
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  subdir:   ouroboros-consensus-protocol
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus-protocol
+  exposed-modules:
+    Ouroboros.Consensus.Protocol.Ledger.HotKey
+    Ouroboros.Consensus.Protocol.Ledger.Util
+    Ouroboros.Consensus.Protocol.Praos
+    Ouroboros.Consensus.Protocol.Praos.Common
+    Ouroboros.Consensus.Protocol.Praos.Header
+    Ouroboros.Consensus.Protocol.Praos.Translate
+    Ouroboros.Consensus.Protocol.Praos.Views
+    Ouroboros.Consensus.Protocol.Praos.VRF
+    Ouroboros.Consensus.Protocol.TPraos
+    Ouroboros.Consensus.Protocol.Translate
+
+  build-depends:
+    , base                     >=4.14 && <4.19
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-binary
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cborg
+    , containers
+    , mtl
+    , nothunks
+    , ouroboros-consensus      >=0.8  && <0.11
+    , serialise
+    , text
+
+library protocol-testlib
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/protocol-testlib
+  exposed-modules: Test.Consensus.Protocol.Serialisation.Generators
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-tests
+    , cardano-ledger-shelley-test
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , ouroboros-consensus-protocol
+    , QuickCheck

--- a/_sources/ouroboros-consensus/0.10.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.10.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-19T21:30:30Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "2097e06a2ede5ba49ec54fed76763af18bc7fccf" }
 subdir = 'ouroboros-consensus'
+
+[[revisions]]
+number = 1
+timestamp = 2023-08-21T08:45:03Z

--- a/_sources/ouroboros-consensus/0.10.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus/0.10.0.0/revisions/1.cabal
@@ -1,0 +1,663 @@
+cabal-version:   3.0
+name:            ouroboros-consensus
+version:         0.10.0.0
+synopsis:        Consensus layer for the Ouroboros blockchain protocol
+description:     Consensus layer for the Ouroboros blockchain protocol.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+flag expose-sublibs
+  description: Expose all private sublibraries
+  manual:      True
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus
+  exposed-modules:
+    Data.SOP.Counting
+    Data.SOP.Functors
+    Data.SOP.Index
+    Data.SOP.InPairs
+    Data.SOP.Lenses
+    Data.SOP.Match
+    Data.SOP.NonEmpty
+    Data.SOP.OptNP
+    Data.SOP.Strict
+    Data.SOP.Tails
+    Data.SOP.Telescope
+    Ouroboros.Consensus.Block
+    Ouroboros.Consensus.Block.Abstract
+    Ouroboros.Consensus.Block.EBB
+    Ouroboros.Consensus.Block.Forging
+    Ouroboros.Consensus.Block.NestedContent
+    Ouroboros.Consensus.Block.RealPoint
+    Ouroboros.Consensus.Block.SupportsMetrics
+    Ouroboros.Consensus.Block.SupportsProtocol
+    Ouroboros.Consensus.BlockchainTime
+    Ouroboros.Consensus.BlockchainTime.API
+    Ouroboros.Consensus.BlockchainTime.WallClock.Default
+    Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+    Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+    Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Config
+    Ouroboros.Consensus.Config.SecurityParam
+    Ouroboros.Consensus.Config.SupportsNode
+    Ouroboros.Consensus.Forecast
+    Ouroboros.Consensus.Fragment.Diff
+    Ouroboros.Consensus.Fragment.InFuture
+    Ouroboros.Consensus.Fragment.Validated
+    Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.HardFork.Abstract
+    Ouroboros.Consensus.HardFork.Combinator
+    Ouroboros.Consensus.HardFork.Combinator.Abstract
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+    Ouroboros.Consensus.HardFork.Combinator.Basics
+    Ouroboros.Consensus.HardFork.Combinator.Block
+    Ouroboros.Consensus.HardFork.Combinator.Compat
+    Ouroboros.Consensus.HardFork.Combinator.Condense
+    Ouroboros.Consensus.HardFork.Combinator.Degenerate
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+    Ouroboros.Consensus.HardFork.Combinator.Forging
+    Ouroboros.Consensus.HardFork.Combinator.Info
+    Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+    Ouroboros.Consensus.HardFork.Combinator.Ledger
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    Ouroboros.Consensus.HardFork.Combinator.Lifting
+    Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.Node
+    Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+    Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+    Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+    Ouroboros.Consensus.HardFork.Combinator.Protocol
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+    Ouroboros.Consensus.HardFork.Combinator.State
+    Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    Ouroboros.Consensus.HardFork.Combinator.State.Instances
+    Ouroboros.Consensus.HardFork.Combinator.State.Lift
+    Ouroboros.Consensus.HardFork.Combinator.State.Types
+    Ouroboros.Consensus.HardFork.Combinator.Translation
+    Ouroboros.Consensus.HardFork.History
+    Ouroboros.Consensus.HardFork.History.Caching
+    Ouroboros.Consensus.HardFork.History.EpochInfo
+    Ouroboros.Consensus.HardFork.History.EraParams
+    Ouroboros.Consensus.HardFork.History.Qry
+    Ouroboros.Consensus.HardFork.History.Summary
+    Ouroboros.Consensus.HardFork.History.Util
+    Ouroboros.Consensus.HardFork.Simple
+    Ouroboros.Consensus.HeaderStateHistory
+    Ouroboros.Consensus.HeaderValidation
+    Ouroboros.Consensus.Ledger.Abstract
+    Ouroboros.Consensus.Ledger.Basics
+    Ouroboros.Consensus.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.Ledger.Dual
+    Ouroboros.Consensus.Ledger.Extended
+    Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Query
+    Ouroboros.Consensus.Ledger.Query.Version
+    Ouroboros.Consensus.Ledger.SupportsMempool
+    Ouroboros.Consensus.Ledger.SupportsPeerSelection
+    Ouroboros.Consensus.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Mempool
+    Ouroboros.Consensus.Mempool.API
+    Ouroboros.Consensus.Mempool.Capacity
+    Ouroboros.Consensus.Mempool.Impl.Common
+    Ouroboros.Consensus.Mempool.Init
+    Ouroboros.Consensus.Mempool.Query
+    Ouroboros.Consensus.Mempool.TxSeq
+    Ouroboros.Consensus.Mempool.Update
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+    Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.InitStorage
+    Ouroboros.Consensus.Node.NetworkProtocolVersion
+    Ouroboros.Consensus.Node.ProtocolInfo
+    Ouroboros.Consensus.Node.Run
+    Ouroboros.Consensus.Node.Serialisation
+    Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Protocol.Abstract
+    Ouroboros.Consensus.Protocol.BFT
+    Ouroboros.Consensus.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Protocol.MockChainSel
+    Ouroboros.Consensus.Protocol.ModChainSel
+    Ouroboros.Consensus.Protocol.PBFT
+    Ouroboros.Consensus.Protocol.PBFT.Crypto
+    Ouroboros.Consensus.Protocol.PBFT.State
+    Ouroboros.Consensus.Protocol.Signed
+    Ouroboros.Consensus.Storage.ChainDB
+    Ouroboros.Consensus.Storage.ChainDB.API
+    Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+    Ouroboros.Consensus.Storage.ChainDB.Impl
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+    Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
+    Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Query
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+    Ouroboros.Consensus.Storage.ChainDB.Init
+    Ouroboros.Consensus.Storage.Common
+    Ouroboros.Consensus.Storage.ImmutableDB
+    Ouroboros.Consensus.Storage.ImmutableDB.API
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
+    Ouroboros.Consensus.Storage.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+    Ouroboros.Consensus.Storage.LedgerDB.Init
+    Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.Query
+    Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+    Ouroboros.Consensus.Storage.LedgerDB.Stream
+    Ouroboros.Consensus.Storage.LedgerDB.Update
+    Ouroboros.Consensus.Storage.Serialisation
+    Ouroboros.Consensus.Storage.VolatileDB
+    Ouroboros.Consensus.Storage.VolatileDB.API
+    Ouroboros.Consensus.Storage.VolatileDB.Impl
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
+    Ouroboros.Consensus.Ticked
+    Ouroboros.Consensus.TypeFamilyWrappers
+    Ouroboros.Consensus.Util
+    Ouroboros.Consensus.Util.AnchoredFragment
+    Ouroboros.Consensus.Util.Args
+    Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.CallStack
+    Ouroboros.Consensus.Util.CBOR
+    Ouroboros.Consensus.Util.Condense
+    Ouroboros.Consensus.Util.DepPair
+    Ouroboros.Consensus.Util.EarlyExit
+    Ouroboros.Consensus.Util.Enclose
+    Ouroboros.Consensus.Util.FileLock
+    Ouroboros.Consensus.Util.HList
+    Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.MonadSTM.NormalForm
+    Ouroboros.Consensus.Util.MonadSTM.RAWLock
+    Ouroboros.Consensus.Util.MonadSTM.StrictSVar
+    Ouroboros.Consensus.Util.Orphans
+    Ouroboros.Consensus.Util.RedundantConstraints
+    Ouroboros.Consensus.Util.ResourceRegistry
+    Ouroboros.Consensus.Util.Singletons
+    Ouroboros.Consensus.Util.STM
+    Ouroboros.Consensus.Util.TentativeState
+    Ouroboros.Consensus.Util.Time
+    Ouroboros.Consensus.Util.TraceSize
+    Ouroboros.Consensus.Util.Versioned
+
+  build-depends:
+    , base                         >=4.14     && <4.19
+    , base16-bytestring
+    , bimap                        >=0.4      && <0.6
+    , binary                       >=0.8      && <0.11
+    , bytestring                   >=0.10     && <0.12
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-prelude
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                        >=0.2.2    && <0.3
+    , containers                   >=0.5      && <0.7
+    , contra-tracer
+    , deepseq
+    , filelock
+    , fs-api                       ^>=0.2
+    , hashable
+    , io-classes                   ^>=1.1
+    , measures
+    , mtl
+    , nothunks                     >=0.1.2    && <0.2
+    , ouroboros-network-api        ^>=0.5
+    , ouroboros-network-mock       ^>=0.1.0.1
+    , ouroboros-network-protocols  ^>=0.5
+    , psqueues                     >=0.2.3    && <0.3
+    , quiet                        >=0.2      && <0.3
+    , semialign                    >=1.1
+    , serialise                    >=0.2      && <0.3
+    , si-timers                    ^>=1.1
+    , sop-core                     >=0.5      && <0.6
+    , streaming
+    , strict-stm                   ^>=1.1
+    , text                         ^>=2.0
+    , these                        ^>=1.2
+    , time
+    , transformers
+    , typed-protocols
+    , vector                       >=0.12     && <0.13
+
+library consensus-testlib
+  import:          common-lib
+  hs-source-dirs:  src/consensus-testlib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  exposed-modules:
+    Test.Util.BoolProps
+    Test.Util.ChainDB
+    Test.Util.ChainUpdates
+    Test.Util.ChunkInfo
+    Test.Util.Corruption
+    Test.Util.FileLock
+    Test.Util.HardFork.Future
+    Test.Util.HardFork.OracularClock
+    Test.Util.InvertedMap
+    Test.Util.LogicalClock
+    Test.Util.MockChain
+    Test.Util.Orphans.Arbitrary
+    Test.Util.Orphans.IOLike
+    Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.SignableRepresentation
+    Test.Util.Orphans.ToExpr
+    Test.Util.Paths
+    Test.Util.QSM
+    Test.Util.QuickCheck
+    Test.Util.Range
+    Test.Util.RefEnv
+    Test.Util.Schedule
+    Test.Util.Serialisation.Golden
+    Test.Util.Serialisation.Roundtrip
+    Test.Util.Shrink
+    Test.Util.Slots
+    Test.Util.SOP
+    Test.Util.Split
+    Test.Util.Stream
+    Test.Util.TestBlock
+    Test.Util.TestEnv
+    Test.Util.Time
+    Test.Util.Tracer
+    Test.Util.WithEq
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-prelude
+    , cardano-strict-containers
+    , cborg
+    , containers
+    , contra-tracer
+    , deepseq
+    , directory
+    , file-embed
+    , filepath
+    , fs-api                                                  ^>=0.2
+    , fs-sim                                                  ^>=0.2
+    , generics-sop
+    , io-sim
+    , mtl
+    , nothunks
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , QuickCheck
+    , quickcheck-state-machine
+    , quiet
+    , random
+    , serialise
+    , sop-core
+    , tasty
+    , tasty-golden
+    , tasty-quickcheck
+    , template-haskell
+    , time
+    , tree-diff
+    , utf8-string
+
+library mock-block
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/mock-block
+  exposed-modules:
+    Ouroboros.Consensus.Mock.Ledger
+    Ouroboros.Consensus.Mock.Ledger.Address
+    Ouroboros.Consensus.Mock.Ledger.Block
+    Ouroboros.Consensus.Mock.Ledger.Block.BFT
+    Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+    Ouroboros.Consensus.Mock.Ledger.Block.Praos
+    Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+    Ouroboros.Consensus.Mock.Ledger.Forge
+    Ouroboros.Consensus.Mock.Ledger.Stake
+    Ouroboros.Consensus.Mock.Ledger.State
+    Ouroboros.Consensus.Mock.Ledger.UTxO
+    Ouroboros.Consensus.Mock.Node
+    Ouroboros.Consensus.Mock.Node.Abstract
+    Ouroboros.Consensus.Mock.Node.BFT
+    Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Praos
+    Ouroboros.Consensus.Mock.Node.PraosRule
+    Ouroboros.Consensus.Mock.Node.Serialisation
+    Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Mock.Protocol.Praos
+
+  build-depends:
+    , base
+    , bimap
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , deepseq
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , serialise
+    , time
+
+library mempool-test-utils
+  import:          common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs:  src/mempool-test-utils
+  exposed-modules: Test.Consensus.Mempool.Mocked
+  build-depends:
+    , base
+    , contra-tracer
+    , deepseq
+    , ouroboros-consensus
+    , strict-stm
+
+library tutorials
+  import:         common-lib
+
+  if flag(expose-sublibs)
+    visibility: public
+
+  else
+    buildable: False
+
+  hs-source-dirs: src/tutorials
+  other-modules:
+    Ouroboros.Consensus.Tutorial.Simple
+    Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:
+    , base
+    , containers
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , serialise
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.HardFork.Forecast
+    Test.Consensus.HardFork.History
+    Test.Consensus.HardFork.Infra
+    Test.Consensus.HardFork.Summary
+    Test.Consensus.Mempool
+    Test.Consensus.Mempool.Fairness
+    Test.Consensus.Mempool.Fairness.TestBlock
+    Test.Consensus.MiniProtocol.BlockFetch.Client
+    Test.Consensus.MiniProtocol.ChainSync.Client
+    Test.Consensus.MiniProtocol.LocalStateQuery.Server
+    Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.NormalForm
+    Test.Consensus.Util.MonadSTM.RAWLock
+    Test.Consensus.Util.Versioned
+
+  build-depends:
+    , async
+    , base
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , fs-api                                                              ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mock-block
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , QuickCheck
+    , quickcheck-state-machine
+    , random
+    , serialise
+    , si-timers
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , time
+    , tree-diff
+    , typed-protocols
+    , typed-protocols-examples
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:
+    Ouroboros.Consensus.Util.Tests
+    Test.Util.ChainUpdates.Tests
+    Test.Util.Schedule.Tests
+    Test.Util.Split.Tests
+
+  build-depends:
+    , base
+    , ouroboros-consensus:{ouroboros-consensus, consensus-testlib}
+    , QuickCheck
+    , tasty
+    , tasty-quickcheck
+
+test-suite storage-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/storage-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Ouroboros.Storage
+    Test.Ouroboros.Storage.ChainDB
+    Test.Ouroboros.Storage.ChainDB.FollowerPromptness
+    Test.Ouroboros.Storage.ChainDB.GcSchedule
+    Test.Ouroboros.Storage.ChainDB.Iterator
+    Test.Ouroboros.Storage.ChainDB.Model
+    Test.Ouroboros.Storage.ChainDB.Model.Test
+    Test.Ouroboros.Storage.ChainDB.Paths
+    Test.Ouroboros.Storage.ChainDB.StateMachine
+    Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl
+    Test.Ouroboros.Storage.ChainDB.Unit
+    Test.Ouroboros.Storage.ImmutableDB
+    Test.Ouroboros.Storage.ImmutableDB.Mock
+    Test.Ouroboros.Storage.ImmutableDB.Model
+    Test.Ouroboros.Storage.ImmutableDB.Primary
+    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    Test.Ouroboros.Storage.LedgerDB
+    Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+    Test.Ouroboros.Storage.LedgerDB.InMemory
+    Test.Ouroboros.Storage.LedgerDB.OnDisk
+    Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
+    Test.Ouroboros.Storage.Orphans
+    Test.Ouroboros.Storage.TestBlock
+    Test.Ouroboros.Storage.VolatileDB
+    Test.Ouroboros.Storage.VolatileDB.Mock
+    Test.Ouroboros.Storage.VolatileDB.Model
+    Test.Ouroboros.Storage.VolatileDB.StateMachine
+
+  build-depends:
+    , base
+    , bifunctors
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , fs-api                    ^>=0.2
+    , fs-sim                    ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  ^>=0.7
+    , random
+    , serialise
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , time
+    , transformers
+    , tree-diff
+    , vector
+
+benchmark mempool-bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench/mempool-bench
+  main-is:          Main.hs
+  other-modules:
+    Bench.Consensus.Mempool
+    Bench.Consensus.Mempool.TestBlock
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-slotting
+    , cassava
+    , consensus-testlib
+    , containers
+    , contra-tracer
+    , deepseq
+    , mempool-test-utils
+    , nothunks
+    , ouroboros-consensus
+    , serialise
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , text
+    , transformers
+    , tree-diff
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors -rtsopts -with-rtsopts=-A32m
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64


### PR DESCRIPTION
Alternative to #445, see https://github.com/input-output-hk/cardano-haskell-packages/pull/445#issuecomment-1685878155

Revision diff is just adding the respective `else buildable: False` branches; will be mirrored in Consensus if this PR is merged.