### PR TITLE
Put folder, not file into hydra-build-products

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -42,7 +42,7 @@ let
       modules = [{
         postHaddock = ''
           mkdir $doc/nix-support
-          echo "doc haddock $docdir/html/index.html" >> $doc/nix-support/hydra-build-products
+          echo "doc haddock $docdir/html" >> $doc/nix-support/hydra-build-products
         '';
       }];
     }


### PR DESCRIPTION
If we put the index.html in there, we'll end up getting index.html for all parts, which we don't want. We need the relative base for this to work. 

Using index.html means that we are trying to look up
- https://ci.iog.io/build/722545/download/1/linuwial.css
- https://ci.iog.io/build/722545/download/1/quick-jump.css for 
- https://ci.iog.io/build/722545/download/1/index.html

which do not exist, as hydra only knows about the explicit index.html build product. Putting the html folder in there should give them all the proper relative path. See also: [NixOS/nix/flake.nix#L615]( https://github.com/NixOS/nix/blob/0a6ac133cfd1c86b8f6062b8b12e5aac8e18df3c/flake.nix#L615)

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
