### PR TITLE
Clean up version flags in add-from-github

### DIFF
--- a/scripts/add-from-github.sh
+++ b/scripts/add-from-github.sh
@@ -6,31 +6,26 @@ set -o pipefail
 SCRIPT_DIR=$(dirname "$(which "$0")")
 
 function usage {
-  echo "Usage $(basename "$0") [-r REVISION] [-v VERSION] REPO_URL COMMIT-SHA [SUBDIRS...]"
+  echo "Usage $(basename "$0") [-f OVERWRITE_VERSION] REPO_URL COMMIT-SHA [SUBDIRS...]"
   echo
-  echo "        -r REVISION     adds .0.0.0.0.REVISION to the package version"
-  echo "        -v VERSION      uses VERSION as the package version"
-  echo "        REPO_URL        the repository's Github URL"
-  echo "        COMMIT_SHA      the commit SHA that corresponds to the revision/version"
-  echo "        SUBDIRS         the list of relevant sub-directories"
+  echo "        -f OVERWRITE_VERSION      (DANGEROUS) uses OVERWRITE_VERSION as the package version instead of the one from the tarball"
+  echo "        REPO_URL                  the repository's Github URL"
+  echo "        COMMIT_SHA                the commit SHA for the package source"
+  echo "        SUBDIRS                   the list of relevant sub-directories"
   exit
 }
 
 optstring=":hr:v:"
 
-REVISION=
-VERSION=
+OVERWRITE_VERSION=
 
 while getopts ${optstring} arg; do
   case ${arg} in
     h)
       usage
       ;;
-    r)
-      REVISION="${OPTARG}"
-      ;;
-    v)
-      VERSION="${OPTARG}"
+    f)
+      OVERWRITE_VERSION="${OPTARG}"
       ;;
     :)
       echo "$0: Must supply an argument to -$OPTARG." >&2
@@ -43,11 +38,6 @@ while getopts ${optstring} arg; do
   esac
 done
 
-if [[ -n $VERSION && -n $REVISION ]]; then
-  echo "You can either use -r or -v but not both at the same time"
-  exit 1
-fi
-
 shift $((OPTIND - 1))
 
 REPO_URL="$1" # e.g. https://github.com/input-output-hk/optparse-applicative
@@ -59,8 +49,8 @@ fi
 
 SUBDIRS=("$@")
 
-if [[ ${#SUBDIRS[@]} -gt 1 && (-n $VERSION || -n $REVISION) ]]; then
-  echo "You can use -r or -v only with a single package"
+if [[ ${#SUBDIRS[@]} -gt 1 && (-n $OVERWRITE_VERSION) ]]; then
+  echo "You can use -f only with a single package"
   exit 1
 fi
 
@@ -113,10 +103,8 @@ do_package() {
   local PKG_VERSION
   PKG_VERSION=$(awk -v IGNORECASE=1 '/^version/ { print $2 }' "$CABAL_FILE")
 
-  if [[ -n $VERSION ]]; then
-    PKG_VERSION="$VERSION"
-  elif [[ -n $REVISION ]]; then
-    PKG_VERSION="${PKG_VERSION}.0.0.0.0.${REVISION}"
+  if [[ -n $OVERWRITE_VERSION ]]; then
+    PKG_VERSION="$OVERWRITE_VERSION"
   fi
 
   local PKG_ID="$PKG_NAME-$PKG_VERSION"
@@ -138,7 +126,7 @@ do_package() {
   fi
 
   mkdir -p "$(dirname "$METAFILE")"
-  render_meta "$TIMESTAMP" "$REPO_URL" "$REPO_REV" "$SUBDIR" "$REVISION$VERSION" > "$METAFILE"
+  render_meta "$TIMESTAMP" "$REPO_URL" "$REPO_REV" "$SUBDIR" "$OVERWRITE_VERSION" > "$METAFILE"
   log "Written $METAFILE"
 
   git add "$METAFILE"


### PR DESCRIPTION
- The flag to force the version was appealingly named `-v` and looked like you were just supposed to always pass the version. I made it scary and changed the flag so that anyone who is currently using it gets tripped up
- The "revision" flag is extremely confusing given we also have, you know, revisions. It's also not used that much, so I just removed it.