### PR TITLE
Release cardano-node packages from 8.3.0-pre tag

### DIFF
--- a/_sources/cardano-git-rev/0.1.3.0/meta.toml
+++ b/_sources/cardano-git-rev/0.1.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'cardano-git-rev'

--- a/_sources/cardano-node-capi/0.1.0.1/meta.toml
+++ b/_sources/cardano-node-capi/0.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'cardano-node-capi'

--- a/_sources/cardano-node-chairman/8.3.0/meta.toml
+++ b/_sources/cardano-node-chairman/8.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:58Z
+github = { repo = "input-output-hk/cardano-node/", rev = "d8bb11b18" }
+subdir = 'cardano-node-chairman'

--- a/_sources/cardano-node/8.3.0/meta.toml
+++ b/_sources/cardano-node/8.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'cardano-node'

--- a/_sources/cardano-submit-api/3.1.4/meta.toml
+++ b/_sources/cardano-submit-api/3.1.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'cardano-submit-api'

--- a/_sources/cardano-testnet/8.3.0/meta.toml
+++ b/_sources/cardano-testnet/8.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'cardano-testnet'

--- a/_sources/cardano-topology/8.2.0/meta.toml
+++ b/_sources/cardano-topology/8.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'bench/cardano-topology'

--- a/_sources/cardano-tracer/0.1.2/meta.toml
+++ b/_sources/cardano-tracer/0.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:57:01Z
+github = { repo = "input-output-hk/cardano-node/", rev = "be4956917" }
+subdir = 'cardano-tracer'

--- a/_sources/locli/1.32/meta.toml
+++ b/_sources/locli/1.32/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'bench/locli'

--- a/_sources/plutus-scripts-bench/1.0.0.2/meta.toml
+++ b/_sources/plutus-scripts-bench/1.0.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'bench/plutus-scripts-bench'

--- a/_sources/trace-analyzer/0.1.0/meta.toml
+++ b/_sources/trace-analyzer/0.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'bench/trace-analyzer'

--- a/_sources/trace-analyzer/0.1.0/meta.toml
+++ b/_sources/trace-analyzer/0.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-09-06T17:11:48Z
 github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
 subdir = 'bench/trace-analyzer'
+
+[[revisions]]
+number = 1
+timestamp = 2023-09-06T17:34:00Z

--- a/_sources/trace-analyzer/0.1.0/revisions/1.cabal
+++ b/_sources/trace-analyzer/0.1.0/revisions/1.cabal
@@ -1,0 +1,59 @@
+cabal-version: 3.0
+
+name:                   trace-analyzer
+version:                0.1.0
+synopsis:               See README for more info
+description:            See README for more info.
+category:               Cardano,
+                        Trace,
+copyright:              2022-2023 Input Output Global Inc (IOG).
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-doc-files:        README.md
+                        CHANGELOG.md
+
+common project-config
+  default-language:     Haskell2010
+  build-depends:        base >= 4.14 && < 5
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wno-orphans
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  default-extensions:   OverloadedStrings
+
+executable trace-analyzer
+  import:               project-config
+
+  hs-source-dirs:       src
+
+  main-is:              trace-analyzer.hs
+
+  build-depends:        aeson ^>=2.1
+                      , optparse-applicative
+                      , text
+                      , containers
+                      , attoparsec
+                      , bytestring
+                      , vector
+
+  ghc-options:          -threaded
+                        -rtsopts
+                        -with-rtsopts=-T
+
+  other-modules:        Paths_trace_analyzer
+  autogen-modules:      Paths_trace_analyzer
+  other-modules:        Cardano.Tracer.Analyze.CLI
+                      , Cardano.Tracer.Analyze.Process
+                      , Cardano.Tracer.Analyze.Types
+                      , Cardano.Tracer.Analyze.Report

--- a/_sources/trace-dispatcher/2.0.3/meta.toml
+++ b/_sources/trace-dispatcher/2.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'trace-dispatcher'

--- a/_sources/trace-forward/2.0.2/meta.toml
+++ b/_sources/trace-forward/2.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'trace-forward'

--- a/_sources/trace-forward/2.0.2/meta.toml
+++ b/_sources/trace-forward/2.0.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-09-06T17:11:48Z
 github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
 subdir = 'trace-forward'
+
+[[revisions]]
+number = 1
+timestamp = 2023-09-06T17:12:00Z

--- a/_sources/trace-forward/2.0.2/revisions/1.cabal
+++ b/_sources/trace-forward/2.0.2/revisions/1.cabal
@@ -1,0 +1,111 @@
+cabal-version: 3.0
+
+name:                   trace-forward
+version:                2.0.2
+synopsis:               The forwarding protocols library for cardano node.
+description:            The library providing typed protocols for forwarding different
+                        information from the cardano node to an external application.
+category:               Cardano,
+                        Trace,
+copyright:              2021-2023 Input Output Global Inc (IOG).
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-doc-files:        README.md
+                        CHANGELOG.md
+
+common project-config
+  default-language:     Haskell2010
+  build-depends:        base >= 4.14 && < 5
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wno-orphans
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               project-config
+  hs-source-dirs:       src
+
+  exposed-modules:      Trace.Forward.Protocol.DataPoint.Acceptor
+                        Trace.Forward.Protocol.DataPoint.Codec
+                        Trace.Forward.Protocol.DataPoint.Forwarder
+                        Trace.Forward.Protocol.DataPoint.Type
+                        Trace.Forward.Protocol.TraceObject.Acceptor
+                        Trace.Forward.Protocol.TraceObject.Codec
+                        Trace.Forward.Protocol.TraceObject.Forwarder
+                        Trace.Forward.Protocol.TraceObject.Type
+
+                        Trace.Forward.Run.DataPoint.Acceptor
+                        Trace.Forward.Run.DataPoint.Forwarder
+                        Trace.Forward.Run.TraceObject.Acceptor
+                        Trace.Forward.Run.TraceObject.Forwarder
+
+                        Trace.Forward.Configuration.DataPoint
+                        Trace.Forward.Configuration.TraceObject
+
+                        Trace.Forward.Utils.DataPoint
+                        Trace.Forward.Utils.TraceObject
+
+  build-depends:        aeson
+                      , async
+                      , bytestring
+                      , cborg
+                      , containers
+                      , contra-tracer
+                      , deepseq
+                      , extra
+                      , io-classes
+                      , ouroboros-network-api >= 0.3
+                      , ouroboros-network-framework ^>= 0.7
+                      , serialise
+                      , stm
+                      , text
+                      , typed-protocols ^>= 0.1
+                      , typed-protocols-cborg
+
+test-suite test
+  import:               project-config
+  type:                 exitcode-stdio-1.0
+  main-is:              Main.hs
+  hs-source-dirs:       test
+
+  other-modules:        Test.Trace.Forward.Protocol.TraceObject.Codec
+                        Test.Trace.Forward.Protocol.TraceObject.Direct
+                        Test.Trace.Forward.Protocol.TraceObject.Examples
+                        Test.Trace.Forward.Protocol.TraceObject.Item
+                        Test.Trace.Forward.Protocol.TraceObject.Tests
+
+                        Test.Trace.Forward.Protocol.DataPoint.Codec
+                        Test.Trace.Forward.Protocol.DataPoint.Direct
+                        Test.Trace.Forward.Protocol.DataPoint.Examples
+                        Test.Trace.Forward.Protocol.DataPoint.Item
+                        Test.Trace.Forward.Protocol.DataPoint.Tests
+
+                        Test.Trace.Forward.Protocol.Common
+
+  build-depends:        aeson
+                      , bytestring
+                      , contra-tracer
+                      , io-classes
+                      , io-sim
+                      , ouroboros-network-api
+                      , ouroboros-network-framework
+                      , trace-forward
+                      , QuickCheck
+                      , serialise
+                      , tasty
+                      , tasty-quickcheck
+                      , typed-protocols ^>= 0.1
+                      , text
+
+  ghc-options:          -rtsopts
+                        -threaded

--- a/_sources/tx-generator/2.7/meta.toml
+++ b/_sources/tx-generator/2.7/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-09-06T17:11:48Z
+github = { repo = "input-output-hk/cardano-node/", rev = "8.3.0-pre" }
+subdir = 'bench/tx-generator'

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
               # packages that depend on the plutus-tx plugin have broken haddock
               packages = {
                 plutus-ledger.doHaddock = false;
+                plutus-scripts-bench.doHaddock = false;
                 cardano-ledger-alonzo.doHaddock = false;
                 cardano-ledger-conway.doHaddock = false;
                 cardano-ledger-babbage.doHaddock = false;


### PR DESCRIPTION
These commits resulted from the following commands:

```
$ ./scripts/add-from-github.sh https://github.com/input-output-hk/cardano-node/ 8.3.0-pre cardano-git-rev cardano-node-capi cardano-node cardano-submit-api cardano-testnet bench/cardano-topology cardano-tracer bench/locli bench/plutus-scripts-bench trace-dispatcher bench/trace-analyzer trace-forward trace-resources bench/tx-generator
$ ./scripts/add-from-github.sh https://github.com/input-output-hk/cardano-node/ d8bb11b18  cardano-node-chairman
$ /scripts/add-from-github.sh https://github.com/input-output-hk/cardano-node/ be4956917  cardano-tracer
$ emacs -nw _source/trace-forward/2.0.2/meta.toml # manually add a revision for trace-forward
$ emacs -nw _source/trace-analyzer/2.0.2/meta.toml # manually add a revision for trace-analyzer
$ emacs -nw flake.nix # disable haddock pass for plutus-scripts-bench
```

It warned that `tracer-resources` was skipped, since its `.cabal` file's `version:` field has not changed. `tracer-resources` indeed did not change.

There's a separate command for `cardano-node-chairman` because of https://github.com/input-output-hk/cardano-node/pull/5459