### PR TITLE
Node 8.3.1 does build on 9.6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,9 +70,6 @@
       #   compilers (defined above) are included.
       #
       exceptions = {
-        cardano-node = {
-          ghc96.enabled = false;
-        };
         plutus-ledger = {
           ghc92.enabled = false;
           ghc96.enabled = false;


### PR DESCRIPTION
This just got added, which is why I missed it. (The previous version did not work).

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
