### PR TITLE
cardano-prelude now support ghc-9.8

### DIFF
--- a/_sources/cardano-prelude/0.1.0.4/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2023-11-16T05:01:28Z
+github = { repo = "input-output-hk/cardano-prelude", rev = "a6f18f78f325c0c5d33877ecb99d7fe6b282f35c" }
+subdir = 'cardano-prelude'


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
