### PR TITLE
Add 9.8 to CI, remove 9.2 and 9.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -198,14 +198,51 @@
         "type": "github"
       }
     },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697054644,
+        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "ref": "refs/heads/master",
+        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
+        "revCount": 62040,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1699662136,
-        "narHash": "sha256-rJGKqW4wqVGZ5XcCHYTXNPQtpSn1XexfRUm6QLWIctY=",
+        "lastModified": 1700094160,
+        "narHash": "sha256-y1DizNnB0sWD3u6RrYQyUJHlVreeNFK5ifarm82hq34=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d35b4834083dec7af29d5d9a597735f89e9a7280",
+        "rev": "dd5ff9b3ea88763bc7686a9ef7e439cd1f24e9da",
         "type": "github"
       },
       "original": {
@@ -222,14 +259,17 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc98X": "ghc98X",
+        "ghc99": "ghc99",
         "hackage": [
           "hackage-nix"
         ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -248,11 +288,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1693795950,
-        "narHash": "sha256-tvTquqMdRQqBbefNO7f+198hq3VuVlY0rjiN5hmzGFw=",
+        "lastModified": 1700095827,
+        "narHash": "sha256-GkkLpXx4atWnEx+mxMH++mc4zH52Q0+kMppRebpG5TA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e166d754a739f5e41d389c537498ccdc6150be0b",
+        "rev": "5598c9b9443624377924fe8cae3f4a6c135f7945",
         "type": "github"
       },
       "original": {
@@ -308,6 +348,40 @@
       "original": {
         "owner": "haskell",
         "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696939266,
+        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -377,11 +451,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -526,11 +600,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
@@ -558,11 +632,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -592,10 +666,7 @@
     "root": {
       "inputs": {
         "CHaP": "CHaP",
-        "flake-utils": [
-          "haskell-nix",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils",
         "foliage": "foliage",
         "hackage-nix": "hackage-nix",
         "haskell-nix": "haskell-nix",
@@ -643,11 +714,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1693786159,
-        "narHash": "sha256-IzpBwbwD90CIdhOKfdzS98+o3AtoADNsSz5QBr281Gg=",
+        "lastModified": 1700093356,
+        "narHash": "sha256-+8dedYSC2vTarOLqgPHcqFh8cJ4OVHciGvYQkIDDS3I=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "69d620fde80c1dfbe78b081db1b5725e9c0ce9e2",
+        "rev": "64744e5be68ebf395164e4d181f433b4cbed6f32",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.follows = "haskell-nix/nixpkgs";
-    flake-utils.follows = "haskell-nix/flake-utils";
+    flake-utils = { url = "github:numtide/flake-utils"; };
 
     foliage = {
       url = "github:input-output-hk/foliage";
@@ -61,7 +61,9 @@
 
       # type CompilerName = String
       # compilers :: [CompilerName]
-      compilers = [ "ghc810" "ghc92" "ghc96" ];
+      compilers = [ "ghc810" "ghc96" "ghc98" ];
+      # compilers which we don't build for by default
+      experimental-compilers = [ "ghc98" ];
 
       # Add exceptions to the CI here.
       #
@@ -72,8 +74,10 @@
       #   compilers (defined above) are included.
       #
       exceptions = {
+        cardano-prelude = {
+          ghc98.enabled = true;
+        };
         plutus-ledger = {
-          ghc92.enabled = false;
           ghc96.enabled = false;
         };
         hasql-dynamic-syntax = {
@@ -113,7 +117,6 @@
           ghc96.enabled = false;
         };
         marlowe-plutus = {
-          ghc92.enabled = false;
           ghc96.enabled = false;
         };
         quickcheck-contractmodel = {
@@ -160,7 +163,10 @@
                 (name: _v:
                   lib.attrByPath
                     [ name compiler "enabled" ]
-                    true
+                    # the default setting depends on whether or not the compiler is
+                    # experimental. Experimental compilers are disabled by default,
+                    # non-experimental compilers are enabled by default
+                    (!(builtins.elem compiler experimental-compilers))
                     exceptions)
                 pkg-versions;
           in

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
 
       # type CompilerName = String
       # compilers :: [CompilerName]
-      compilers = [ "ghc810" "ghc96" "ghc98" ];
+      compilers = [ "ghc810" "ghc92" "ghc96" "ghc98" ];
       # compilers which we don't build for by default
       experimental-compilers = [ "ghc98" ];
 
@@ -78,6 +78,7 @@
           ghc98.enabled = true;
         };
         plutus-ledger = {
+          ghc92.enabled = false;
           ghc96.enabled = false;
         };
         hasql-dynamic-syntax = {
@@ -117,6 +118,7 @@
           ghc96.enabled = false;
         };
         marlowe-plutus = {
+          ghc92.enabled = false;
           ghc96.enabled = false;
         };
         quickcheck-contractmodel = {

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/1kgdgc5q9lf5gcyihlx22m1pfld8fw6p-all-smoke-test-packages


### PR DESCRIPTION
We're moving towards 9.8, we're not going to use 9.2 or 9.4 in the long run.

Since 9.8 is only going to work for a small set of packages to begin with, I added an `experimental-compilers` list. Things in that list are off by default but you can turn them on in `exceptions`.

`cardano-prelude` builds with 9.8 now, so that's our first test!

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
